### PR TITLE
Print error when cat validation fails

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -326,7 +326,8 @@ class CatalogConfig(object):
         schema = CatalogConfigSchema(context=context)
         result = schema.load(data)
         if result.errors:
-            raise ValidationError("Catalog '{}' has validation errors".format(path), result.errors)
+            raise ValidationError("Catalog '{}' has validation errors: {}"
+                                  "".format(path, result.errors), result.errors)
 
         cfg = result.data
 


### PR DESCRIPTION
"has validation errors" is not a very useful message. This line of code surfaces the cause.
