### PR TITLE
Fix Travis tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include intake *.html
 recursive-include intake *.csv
 recursive-include intake *.yml
+recursive-include intake/source/tests/plugin_searchpath *.py
 
 include versioneer.py
 include intake/_version.py


### PR DESCRIPTION
The local tests were passing, but the Travis tests were failing. After some trial-and-error, it turns out that the intake.source plugins used for testing were not installed in the package. Once the plugins were included, then the tests passed.

Fix #22