### PR TITLE
Use entrypoints to manage drivers. Add subcommand.

### DIFF
--- a/docs/source/making-plugins.rst
+++ b/docs/source/making-plugins.rst
@@ -282,7 +282,11 @@ By convention, drivers should have names that are lowercase, valid Python identi
 This approach is deprecated because it is limiting (requires the package to
 begin with "intake_") and because the package scan can be slow. Using
 entrypoints is strongly encouraged. The package scan *may* be disabled by
-default in some future release of intake.
+default in some future release of intake. During the transition period, if a
+package named ``intake_*`` provides an entrypoint for a given name, that will
+take precedence over any drivers gleaned from the package scan having that
+name. If intake discovers any names from the package scan for which there are
+no entrypoints, it will issue a ``FutureWarning``.
 
 Python API to Driver Discovery
 ''''''''''''''''''''''''''''''

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -19,11 +19,11 @@ from .catalog import local
 from .catalog.default import load_combo_catalog
 from .container import upload
 from .source import registry
-from .source.discovery import autodiscover
-from .gui import InstanceMaker
+from .source.discovery import all_enabled_drivers
+from .gui import DataBrowser, InstanceMaker
 
-# Populate list of autodetected plugins
-registry.update(autodiscover())
+# Populate list of autodetected or explicitly configured drivers (plugins).
+registry.update(all_enabled_drivers())
 
 from .source import csv, textfiles, npy, zarr
 registry['csv'] = csv.CSVSource

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -19,11 +19,11 @@ from .catalog import local
 from .catalog.default import load_combo_catalog
 from .container import upload
 from .source import registry
-from .source.discovery import all_enabled_drivers
+from .source.discovery import autodiscover
 from .gui import InstanceMaker
 
-# Populate list of autodetected or explicitly configured drivers (plugins).
-registry.update(all_enabled_drivers())
+# Populate list of autodetected drivers (plugins).
+registry.update(autodiscover())
 
 from .source import csv, textfiles, npy, zarr
 registry['csv'] = csv.CSVSource

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -20,7 +20,7 @@ from .catalog.default import load_combo_catalog
 from .container import upload
 from .source import registry
 from .source.discovery import all_enabled_drivers
-from .gui import DataBrowser, InstanceMaker
+from .gui import InstanceMaker
 
 # Populate list of autodetected or explicitly configured drivers (plugins).
 registry.update(all_enabled_drivers())

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -5,7 +5,6 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from __future__ import absolute_import
 import re
 import warnings
 

--- a/intake/cli/client/subcommands/__init__.py
+++ b/intake/cli/client/subcommands/__init__.py
@@ -15,5 +15,7 @@ from .get import Get
 from .info import Info
 from .list import List
 from .precache import Precache
+from .drivers import Drivers
 
-all  = (Cache, Config, Describe, Discover, Example, Exists, Get, Info, List, Precache)
+all  = (Cache, Config, Describe, Discover, Example, Exists, Get, Info, List,
+        Precache, Drivers)

--- a/intake/cli/client/subcommands/cache.py
+++ b/intake/cli/client/subcommands/cache.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/config.py
+++ b/intake/cli/client/subcommands/config.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/describe.py
+++ b/intake/cli/client/subcommands/describe.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/discover.py
+++ b/intake/cli/client/subcommands/discover.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -5,7 +5,7 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 '''
-
+CLI for listing, enabling, disabling intake drivers
 '''
 
 from __future__ import print_function

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -8,8 +8,6 @@
 CLI for listing, enabling, disabling intake drivers
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -73,12 +73,7 @@ class Drivers(Subcommand):
 
     def _enable(self, args):
         drivers_d = os.path.join(confdir, 'drivers.d')
-        # In Python 3 you can use exist_ok=True for this.
-        try:
-            os.makedirs(drivers_d)
-        except OSError as err:
-            if err.errno != errno.EEXIST:
-                raise
+        os.makedirs(drivers_d, exist_ok=True)
         for driver in args.drivers:
             filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
             if os.path.isfile(filepath):
@@ -92,12 +87,7 @@ class Drivers(Subcommand):
 
     def _disable(self, args):
         drivers_d = os.path.join(confdir, 'drivers.d')
-        # In Python 3 you can use exist_ok=True for this.
-        try:
-            os.makedirs(drivers_d)
-        except OSError as err:
-            if err.errno != errno.EEXIST:
-                raise
+        os.makedirs(drivers_d, exist_ok=True)
         for driver in args.drivers:
             filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
             if os.path.isfile(filepath):

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -50,12 +50,13 @@ class Drivers(Subcommand):
         list.add_argument('-v', '--verbose', action='store_true', help='Show module path.')
         list.set_defaults(invoke=self._list)
 
-        enable = sub_parser.add_parser('enable', help='Enable one or more intake drivers.')
-        enable.add_argument('drivers', type=str, help='Module path and class name, as in package.submodule.ClassName', nargs='+')
+        enable = sub_parser.add_parser('enable', help='Enable an intake driver.')
+        enable.add_argument('name', type=str, help='Driver name')
+        enable.add_argument('driver', type=str, help='Module path and class name, as in package.submodule.ClassName')
         enable.set_defaults(invoke=self._enable)
 
         disable = sub_parser.add_parser('disable', help='Disable one or more intake drivers.')
-        disable.add_argument('drivers', type=str, help='Module path and class name, as in package.submodule.ClassName', nargs='+')
+        disable.add_argument('names', type=str, help='Driver names', nargs='+')
         disable.set_defaults(invoke=self._disable)
 
     def invoke(self, args):
@@ -71,9 +72,8 @@ class Drivers(Subcommand):
                   file=sys.stderr)
 
     def _enable(self, args):
-        for driver in args.drivers:
-            enable(driver)
+        enable(args.name, args.driver)
 
     def _disable(self, args):
-        for driver in args.drivers:
-            disable(driver)
+        for name in args.names:
+            disable(name)

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -1,0 +1,109 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2018, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+'''
+
+'''
+
+from __future__ import print_function
+
+import logging
+log = logging.getLogger(__name__)
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+# Standard library imports
+import errno
+from importlib import import_module
+import inspect
+import os
+import sys
+
+# External imports
+import yaml
+
+# Intake imports
+from intake import __version__
+from intake.cli.util import Subcommand
+from intake.source.discovery import all_enabled_drivers
+from intake.config import confdir
+
+#-----------------------------------------------------------------------------
+# API
+#-----------------------------------------------------------------------------
+
+class Drivers(Subcommand):
+    '''
+    List, enable, and disable intake drivers.
+    '''
+
+    name = "drivers"
+
+    def initialize(self):
+        sub_parser = self.parser.add_subparsers()
+
+        list = sub_parser.add_parser('list', help='Show all intake drivers.')
+        list.add_argument('-v', '--verbose', action='store_true', help='Show module path.')
+        list.set_defaults(invoke=self._list)
+
+        enable = sub_parser.add_parser('enable', help='Enable one or more intake drivers.')
+        enable.add_argument('drivers', type=str, help='Python package name, such as intake_xarray', nargs='+')
+        enable.set_defaults(invoke=self._enable)
+
+        disable = sub_parser.add_parser('disable', help='Disable one or more intake drivers.')
+        disable.add_argument('drivers', type=str, help='Python package name, such as intake_xarray', nargs='+')
+        disable.set_defaults(invoke=self._disable)
+
+    def invoke(self, args):
+        self.parser.print_help()
+
+    def _list(self, args):
+        if args.verbose:
+            fmt = '{name:<30}{cls.__module__}.{cls.__name__} @ {file}'
+        else:
+            fmt = '{name:<30}{cls.__module__}.{cls.__name__}'
+        for name, cls in all_enabled_drivers().items():
+            print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)))
+
+    def _enable(self, args):
+        drivers_d = os.path.join(confdir, 'drivers.d')
+        # In Python 3 you can use exist_ok=True for this.
+        try:
+            os.makedirs(drivers_d)
+        except OSError as err:
+            if err.errno != errno.EEXIST:
+                raise
+        for driver in args.drivers:
+            filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
+            if os.path.isfile(filepath):
+                with open(filepath, 'r') as f:
+                    conf = yaml.load(f.read())
+            else:
+                conf = {}
+            conf.update({driver: {'enabled': True}})
+            with open(filepath, 'w') as f:
+                f.write(yaml.dump(conf, default_flow_style=False))
+
+    def _disable(self, args):
+        drivers_d = os.path.join(confdir, 'drivers.d')
+        # In Python 3 you can use exist_ok=True for this.
+        try:
+            os.makedirs(drivers_d)
+        except OSError as err:
+            if err.errno != errno.EEXIST:
+                raise
+        for driver in args.drivers:
+            filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
+            if os.path.isfile(filepath):
+                with open(filepath, 'r') as f:
+                    conf = yaml.load(f.read())
+            else:
+                conf = {}
+            conf.update({driver: {'enabled': False}})
+            with open(filepath, 'w') as f:
+                f.write(yaml.dump(conf, default_flow_style=False))

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -32,6 +32,7 @@ from intake import __version__
 from intake.cli.util import Subcommand
 from intake.source.discovery import all_enabled_drivers
 from intake.config import confdir
+from ....utils import yaml_load
 
 #-----------------------------------------------------------------------------
 # API
@@ -82,7 +83,7 @@ class Drivers(Subcommand):
             filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
             if os.path.isfile(filepath):
                 with open(filepath, 'r') as f:
-                    conf = yaml.load(f.read())
+                    conf = yaml_load(f.read())
             else:
                 conf = {}
             conf.update({driver: {'enabled': True}})
@@ -101,7 +102,7 @@ class Drivers(Subcommand):
             filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
             if os.path.isfile(filepath):
                 with open(filepath, 'r') as f:
-                    conf = yaml.load(f.read())
+                    conf = yaml_load(f.read())
             else:
                 conf = {}
             conf.update({driver: {'enabled': False}})

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -52,11 +52,11 @@ class Drivers(Subcommand):
         list.set_defaults(invoke=self._list)
 
         enable = sub_parser.add_parser('enable', help='Enable one or more intake drivers.')
-        enable.add_argument('drivers', type=str, help='Python package name, such as intake_xarray', nargs='+')
+        enable.add_argument('drivers', type=str, help='Module path and class name, as in package.submodule.ClassName', nargs='+')
         enable.set_defaults(invoke=self._enable)
 
         disable = sub_parser.add_parser('disable', help='Disable one or more intake drivers.')
-        disable.add_argument('drivers', type=str, help='Python package name, such as intake_xarray', nargs='+')
+        disable.add_argument('drivers', type=str, help='Module path and class name, as in package.submodule.ClassName', nargs='+')
         disable.set_defaults(invoke=self._disable)
 
     def invoke(self, args):

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -29,7 +29,7 @@ import sys
 # Intake imports
 from intake import __version__
 from intake.cli.util import Subcommand
-from intake.source.discovery import autodiscover, enable, disable
+from intake.source.discovery import autodiscover, autodiscover_all, enable, disable
 from intake.config import confdir
 
 #-----------------------------------------------------------------------------
@@ -67,9 +67,17 @@ class Drivers(Subcommand):
             fmt = '{name:<30}{cls.__module__}.{cls.__name__} @ {file}'
         else:
             fmt = '{name:<30}{cls.__module__}.{cls.__name__}'
-        for name, cls in autodiscover().items():
+        drivers_by_name = autodiscover()   # dict mapping name to driver
+        all_drivers = autodiscover_all()  # listof (name, driver)
+        print("Enabled:", file=sys.stderr)
+        for name, cls in drivers_by_name.items():
             print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)),
                   file=sys.stderr)
+        print("\nNot enabled:", file=sys.stderr)
+        for name, cls in all_drivers:
+            if drivers_by_name[name] is not cls:
+                print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)),
+                    file=sys.stderr)
 
     def _enable(self, args):
         enable(args.name, args.driver)

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -25,14 +25,12 @@ import os
 import sys
 
 # External imports
-import yaml
 
 # Intake imports
 from intake import __version__
 from intake.cli.util import Subcommand
-from intake.source.discovery import all_enabled_drivers
+from intake.source.discovery import all_enabled_drivers, enable, disable
 from intake.config import confdir
-from ....utils import yaml_load
 
 #-----------------------------------------------------------------------------
 # API
@@ -69,32 +67,13 @@ class Drivers(Subcommand):
         else:
             fmt = '{name:<30}{cls.__module__}.{cls.__name__}'
         for name, cls in all_enabled_drivers().items():
-            print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)))
+            print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)),
+                  file=sys.stderr)
 
     def _enable(self, args):
-        drivers_d = os.path.join(confdir, 'drivers.d')
-        os.makedirs(drivers_d, exist_ok=True)
         for driver in args.drivers:
-            filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
-            if os.path.isfile(filepath):
-                with open(filepath, 'r') as f:
-                    conf = yaml_load(f.read())
-            else:
-                conf = {}
-            conf.update({driver: {'enabled': True}})
-            with open(filepath, 'w') as f:
-                f.write(yaml.dump(conf, default_flow_style=False))
+            enable(driver)
 
     def _disable(self, args):
-        drivers_d = os.path.join(confdir, 'drivers.d')
-        os.makedirs(drivers_d, exist_ok=True)
         for driver in args.drivers:
-            filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
-            if os.path.isfile(filepath):
-                with open(filepath, 'r') as f:
-                    conf = yaml_load(f.read())
-            else:
-                conf = {}
-            conf.update({driver: {'enabled': False}})
-            with open(filepath, 'w') as f:
-                f.write(yaml.dump(conf, default_flow_style=False))
+            disable(driver)

--- a/intake/cli/client/subcommands/drivers.py
+++ b/intake/cli/client/subcommands/drivers.py
@@ -29,7 +29,7 @@ import sys
 # Intake imports
 from intake import __version__
 from intake.cli.util import Subcommand
-from intake.source.discovery import all_enabled_drivers, enable, disable
+from intake.source.discovery import autodiscover, enable, disable
 from intake.config import confdir
 
 #-----------------------------------------------------------------------------
@@ -66,7 +66,7 @@ class Drivers(Subcommand):
             fmt = '{name:<30}{cls.__module__}.{cls.__name__} @ {file}'
         else:
             fmt = '{name:<30}{cls.__module__}.{cls.__name__}'
-        for name, cls in all_enabled_drivers().items():
+        for name, cls in autodiscover().items():
             print(fmt.format(name=name, cls=cls, file=inspect.getfile(cls)),
                   file=sys.stderr)
 

--- a/intake/cli/client/subcommands/example.py
+++ b/intake/cli/client/subcommands/example.py
@@ -7,8 +7,6 @@
 '''
 
 '''
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/exists.py
+++ b/intake/cli/client/subcommands/exists.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/get.py
+++ b/intake/cli/client/subcommands/get.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/info.py
+++ b/intake/cli/client/subcommands/info.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/list.py
+++ b/intake/cli/client/subcommands/list.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/client/subcommands/precache.py
+++ b/intake/cli/client/subcommands/precache.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/cli/server/__main__.py
+++ b/intake/cli/server/__main__.py
@@ -4,8 +4,6 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from __future__ import print_function
-
 import argparse
 import logging
 import signal

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -4,8 +4,6 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from __future__ import print_function
-
 import time
 from uuid import uuid4
 

--- a/intake/cli/util.py
+++ b/intake/cli/util.py
@@ -8,8 +8,6 @@
 
 '''
 
-from __future__ import print_function
-
 import logging
 log = logging.getLogger(__name__)
 

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -63,8 +63,8 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
         if entrypoint.name in package_scan_results:
             cls = package_scan_results[name]
             del package_scan_results[name]
-            logger.debug("Entrypoint shadowed package_scan result '%s = %s'",
-                         name_, cls.__name__)
+            logger.debug("Entrypoint shadowed package_scan result '%s = %s.%s'",
+                         name_, cls.__module__, cls.__name__)
 
     # Discover drivers via config.
     drivers_conf = conf.get('drivers', {})
@@ -82,8 +82,8 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
             if name in package_scan_results:
                 cls = package_scan_results[name]
                 del package_scan_results[name]
-                logger.debug("Disabled package_scan result '%s = %s'",
-                             name_, cls.__name__)
+                logger.debug("Disabled package_scan result '%s = %s.%s'",
+                             name_, cls.__module__, cls.__name__)
             continue
         module_name, object_name = dotted_object_name.rsplit('.', 1)
         entrypoint = entrypoints.EntryPoint(name, module_name, object_name)
@@ -100,8 +100,8 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
         if name in package_scan_results:
             cls = package_scan_results[name]
             del package_scan_results[name]
-            logger.debug("Config shadowed package scan result '%s = %s'",
-                         name, cls.__name__)
+            logger.debug("Config shadowed package scan result '%s = %s.%s'",
+                         name, cls.__module__, cls.__name__)
         group[name] = entrypoint
 
     # Discovery is complete.
@@ -130,11 +130,12 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
 
     # Now include any package scan results. Any that were shadowed or
     # banned have already been removed above.
-    for name, driver in package_scan_results.items():
-        drivers[name] = driver
-        logger.debug("Loaded package scan result '%s = %s'",
+    for name, cls in package_scan_results.items():
+        drivers[name] = cls
+        logger.debug("Loaded package scan result '%s = %s.%s'",
                      name,
-                     driver.__name__)
+                     cls.__module__,
+                     cls.__name__)
 
     return drivers
 

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -103,6 +103,7 @@ def all_enabled_drivers():
                 driver = enabled_driver(filepath)
             except ConfigurationError:
                 logger.exception("Error reading %s", filepath)
+                continue
             else:
                 if driver and name not in drivers:
                     drivers[name] = cls

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -14,6 +14,8 @@ import inspect
 import time
 import logging
 
+import yaml
+
 from .base import DataSource
 from ..catalog.base import Catalog
 from ..config import confdir
@@ -190,3 +192,31 @@ def load_plugins_from_module(module_name):
 
 class ConfigurationError(Exception):
     pass
+
+
+def enable(driver):
+    drivers_d = os.path.join(confdir, 'drivers.d')
+    os.makedirs(drivers_d, exist_ok=True)
+    filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
+    if os.path.isfile(filepath):
+        with open(filepath, 'r') as f:
+            conf = yaml_load(f.read())
+    else:
+        conf = {}
+    conf.update({driver: {'enabled': True}})
+    with open(filepath, 'w') as f:
+        f.write(yaml.dump(conf, default_flow_style=False))
+
+
+def disable(driver):
+    drivers_d = os.path.join(confdir, 'drivers.d')
+    os.makedirs(drivers_d, exist_ok=True)
+    filepath = '{}.yml'.format(os.path.join(drivers_d, driver))
+    if os.path.isfile(filepath):
+        with open(filepath, 'r') as f:
+            conf = yaml_load(f.read())
+    else:
+        conf = {}
+    conf.update({driver: {'enabled': False}})
+    with open(filepath, 'w') as f:
+        f.write(yaml.dump(conf, default_flow_style=False))

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -52,6 +52,9 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
     """
     # Discover drivers via package scan.
     if do_package_scan:
+        warnings.warn(
+            "The option `do_package_scan` may be removed in a future release.",
+            PendingDeprecationWarning)
         package_scan_results = _package_scan(path, plugin_prefix)
 
     # Discover drivers via entrypoints.
@@ -175,6 +178,9 @@ def autodiscover_all(path=None, plugin_prefix='intake_', do_package_scan=True):
     """
     # Discover drivers via package scan.
     if do_package_scan:
+        warnings.warn(
+            "The option `do_package_scan` may be removed in a future release.",
+            PendingDeprecationWarning)
         package_scan_results = _package_scan(path, plugin_prefix)
 
     # Discover drivers via entrypoints.

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -106,6 +106,13 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
 
     # Discovery is complete.
     
+    if package_scan_results:
+        warnings.warn(
+            f"The drivers {package_scan_results} do not specify entry_points "
+            f"and were only discovered via a package scan. This may break in a "
+            f"future release of intake. The packages should be updated.",
+            FutureWarning)
+
     # Load entrypoints. Any that were shadowed or banned have already been
     # removed above.
     drivers = {}
@@ -119,14 +126,6 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
                      entrypoint.name,
                      entrypoint.module_name,
                      entrypoint.object_name)
-
-    # TODO Un-comment this code to unleash warnings after most known intake_*
-    # packages have been updated to provide 'intake.drivers' entrypoints.
-    # if package_scan_results:
-    #     warnings.warn(
-    #         f"The drivers {package_scan_results} do not specify entry_points "
-    #         f"and were only discovered via a package scan. This may break in a "
-    #         f"future release of intake. The packages should be updated.")
 
     # Now include any package scan results. Any that were shadowed or
     # banned have already been removed above.

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -220,7 +220,7 @@ class ConfigurationError(Exception):
 
 def enable(name, driver):
     """
-    Update config file drivers seciton to explicitly assign a driver to a name.
+    Update config file drivers section to explicitly assign a driver to a name.
 
     Parameters
     ----------
@@ -236,7 +236,7 @@ def enable(name, driver):
 
 
 def disable(name):
-    """Update config file drivers seciton to disable a name.
+    """Update config file drivers section to disable a name.
 
     Parameters
     ----------

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -5,8 +5,6 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import glob
-import os
 import pkgutil
 import warnings
 import importlib
@@ -15,7 +13,6 @@ import time
 import logging
 
 import entrypoints
-import yaml
 
 from .base import DataSource
 from ..catalog.base import Catalog
@@ -141,9 +138,6 @@ def _package_scan(path=None, plugin_prefix='intake_'):
                     plugins[plugin_name] = plugin
             logger.debug("Import %s took: %7.2f s" % (name, time.time() - t))
     return plugins
-
-
-all_enabled_drivers = autodiscover
 
 
 def load_plugins_from_module(module_name):

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -74,12 +74,12 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
                     matches,
                     winner)
 
-    for entrypoint in group.values():
+    for name, entrypoint in group.items():
         logger.debug("Discovered entrypoint '%s = %s.%s'",
-                     entrypoint.name,
+                     name,
                      entrypoint.module_name,
                      entrypoint.object_name)
-        if entrypoint.name in package_scan_results:
+        if name in package_scan_results:
             cls = package_scan_results[name]
             del package_scan_results[name]
             logger.debug("Entrypoint shadowed package_scan result '%s = %s.%s'",

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -17,7 +17,6 @@ import entrypoints
 from .base import DataSource
 from ..catalog.base import Catalog
 from ..config import save_conf, conf
-from ..utils import yaml_load
 logger = logging.getLogger('intake')
 
 

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -92,15 +92,17 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
                      entrypoint.module_name,
                      entrypoint.object_name)
         if name in group:
+            shadowed = group[name]
             logger.debug("Config shadowed entrypoint '%s = %s.%s'",
-                            entrypoint.name,
-                            entrypoint.module_name,
-                            entrypoint.object_name)
+                         shadowed.name,
+                         shadowed.module_name,
+                         shadowed.object_name)
         if name in package_scan_results:
             cls = package_scan_results[name]
             del package_scan_results[name]
             logger.debug("Config shadowed package scan result '%s = %s'",
                          name, cls.__name__)
+        group[name] = entrypoint
 
     # Discovery is complete.
     

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -19,20 +19,91 @@ import yaml
 
 from .base import DataSource
 from ..catalog.base import Catalog
-from ..config import confdir
+from ..config import load_conf, save_conf
 from ..utils import yaml_load
 logger = logging.getLogger('intake')
 
 
-def autodiscover(path=None, plugin_prefix='intake_'):
+def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
+    """Discover intake drivers.
+
+    In order of decreasing precedence:
+    - Respect the 'drivers' section of the intake configuration file.
+    - Find 'intake.drivers' entrypoints provided by any Python packages in the
+      environment.
+    - Search all packages in the environment for names that begin with
+      ``intake_``. Import them and scan them for subclasses of
+      ``intake.source.base.Plugin``. This was previously the *only* mechanism
+      for auto-discoverying intake drivers, and it is maintained for backward
+      compatibility. In a future release, intake will issue a warning if any
+      packages are located by the method that do not also have entrypoints.
+
+    Parameters
+    ----------
+    path : str or None
+        Default is ``sys.path``.
+    plugin_prefix : str
+        DEPRECATED. Default is 'intake_'.
+    do_package_scan : boolean
+        Default is True.
+
+    Returns
+    -------
+    drivers : dict
+        Name mapped to driver class.
+    """
+    if do_package_scan:
+        package_scan_results = _package_scan(path, plugin_prefix)
+
+    drivers = {}
+    group = entrypoints.get_group_all('intake.drivers', path=path)
+    for entrypoint in group:
+        # TODO Refer to intake configuration file to enable only a *subset* of
+        # the installed extensions and/or to give precedence to a specific
+        # driver in the event of a name collision.
+        try:
+            drivers[entrypoint.name] = entrypoint.load()
+        except ModuleNotFoundError:
+            log.error(
+                f"Failed to load {entrypoint.name} driver because module "
+                f"{entrypoint.module_name} could not be found.")
+            continue
+        except ModuleNotFoundError:
+            log.error(
+                f"Failed to load {entrypoint.name} driver because no object "
+                f"named {entrypoint.object_name} could be found in the module "
+                f"{entrypoint.module_name}.")
+            continue
+
+    # TODO Un-comment this code to unleash warnings after most known intake-*
+    # packages have been updated to provide 'intake.drivers' entrypoints.
+    # missing_entry_points = set(package_scan_results) - set(drivers)
+    # if missing_entry_points:
+    #     warnings.warn(
+    #         f"The drivers {missing_entry_points} do not specify entry_points "
+    #         f"and were only discovered via a package scan. This may break in a "
+    #         f"future release of intake. The packages should be updated.")
+    drivers.update(package_scan_results)
+
+    drivers_conf = (load_conf() or {}).get('drivers', {})
+    for name, dotted_object_name in drivers_conf.items():
+        if not dotted_object_name:
+            # This driver is disabled.
+            drivers.pop(name, None)
+        module_name, object_name = dotted_object_name.rpartition('.')
+        mock_entrypoint = entrypoint.EntryPoint(name, module_name, object_name)
+        # If the user has a broken config and this fails, let this raise
+        # instead of just logging.
+        drivers[entrypoint.name] = entrypoint.load()
+    return drivers
+
+def _package_scan(path=None, plugin_prefix='intake_'):
     """Scan for intake drivers and return a dict of plugins.
 
-    This wraps ``entrypoints.get_group_named('intake.drivers')``. In addition,
-    for backward-compatibility, this also searches path (or sys.path) for
-    packages with names that start with plugin_prefix.  Those modules will be
-    imported and scanned for subclasses of intake.source.base.Plugin.  Any
-    subclasses found will be instantiated and returned in a dictionary, with
-    the plugin's name attribute as the key.
+    This searches path (or sys.path) for packages with names that start with
+    plugin_prefix.  Those modules will be imported and scanned for subclasses
+    of intake.source.base.Plugin.  Any subclasses found will be instantiated
+    and returned in a dictionary, with the plugin's name attribute as the key.
     """
 
     plugins = {}
@@ -55,13 +126,6 @@ def autodiscover(path=None, plugin_prefix='intake_'):
                 else:
                     plugins[plugin_name] = plugin
             logger.debug("Import %s took: %7.2f s" % (name, time.time() - t))
-
-    group = entrypoints.get_group_all('intake.drivers')
-    for entrypoint in group:
-        # TODO Refer to intake configuration file to enable only a *subset* of
-        # the installed extensions and/or to give precedence to a specific
-        # driver in the event of a name collision.
-        plugins[entrypoint.name] = entrypoint.load()
     return plugins
 
 

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -42,7 +42,8 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
     plugin_prefix : str
         DEPRECATED. Default is 'intake_'.
     do_package_scan : boolean
-        Default is True.
+        Default is True. In the future, the default will be changed to False,
+        and the option may eventually be removed entirely.
 
     Returns
     -------
@@ -164,7 +165,8 @@ def autodiscover_all(path=None, plugin_prefix='intake_', do_package_scan=True):
     plugin_prefix : str
         DEPRECATED. Default is 'intake_'.
     do_package_scan : boolean
-        Default is True.
+        Default is True. In the future, the default will be changed to False,
+        and the option may eventually be removed entirely.
 
     Returns
     -------

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -145,15 +145,15 @@ def _load_entrypoint(entrypoint):
     """
     try:
         return entrypoint.load()
-    except ModuleNotFoundError:
+    except ModuleNotFoundError as err:
         raise ConfigurationError(
             f"Failed to load {entrypoint.name} driver because module "
-            f"{entrypoint.module_name} could not be found.")
-    except AttributeError:
+            f"{entrypoint.module_name} could not be found.") from err
+    except AttributeError as err:
         raise ConfigurationError(
             f"Failed to load {entrypoint.name} driver because no object "
             f"named {entrypoint.object_name} could be found in the module "
-            f"{entrypoint.module_name}.")
+            f"{entrypoint.module_name}.") from err
 
 
 def _package_scan(path=None, plugin_prefix='intake_'):

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -56,7 +56,7 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
     # Discover drivers via entrypoints.
     group = entrypoints.get_group_named('intake.drivers', path=path)
     group_all = entrypoints.get_group_all('intake.drivers', path=path)
-    if group_all != group:
+    if len(group_all) != len(group):
         # There are some name collisions. Let's go digging for them.
         for name, matches in itertools.groupby(group_all, lambda ep: ep.name):
             matches = list(matches)

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -64,7 +64,7 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
             cls = package_scan_results[name]
             del package_scan_results[name]
             logger.debug("Entrypoint shadowed package_scan result '%s = %s.%s'",
-                         name_, cls.__module__, cls.__name__)
+                         name, cls.__module__, cls.__name__)
 
     # Discover drivers via config.
     drivers_conf = conf.get('drivers', {})
@@ -83,7 +83,7 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
                 cls = package_scan_results[name]
                 del package_scan_results[name]
                 logger.debug("Disabled package_scan result '%s = %s.%s'",
-                             name_, cls.__module__, cls.__name__)
+                             name, cls.__module__, cls.__name__)
             continue
         module_name, object_name = dotted_object_name.rsplit('.', 1)
         entrypoint = entrypoints.EntryPoint(name, module_name, object_name)

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -149,7 +149,7 @@ def _load_entrypoint(entrypoint):
         raise ConfigurationError(
             f"Failed to load {entrypoint.name} driver because module "
             f"{entrypoint.module_name} could not be found.")
-    except ModuleNotFoundError:
+    except AttributeError:
         raise ConfigurationError(
             f"Failed to load {entrypoint.name} driver because no object "
             f"named {entrypoint.object_name} could be found in the module "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # This file is also processed by conda-build, so keep spaces as "pkg >=1.2"
 appdirs
+entrypoints
 dask[bag] >=1.0
 jinja2
 numpy


### PR DESCRIPTION
I would like it to be possible to:

* Provide drivers that are discoverable by intake without necessarily packaging them in a package named `intake*`
* Have the option to _disable_ a specific intake driver from getting autodiscovered without uninstalling the package that provides it or disabling other drivers in that package

I think the [Jupyter notebook serverextension system](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html) has settled on a nice way to manage this kind of configuration (after many iterations and pivots over the years). This PR imitates that system. It's just a first pass to evaluate interest and would need more careful thought before being merged.

Demo:

An `intake drivers` subcommand can list the drivers that are added to `intake.registry` at import time.

```
$ intake drivers list
netcdf                        intake_xarray.netcdf.NetCDFSource
opendap                       intake_xarray.opendap.OpenDapSource
rasterio                      intake_xarray.raster.RasterIOSource
remote-xarray                 intake_xarray.xarray_container.RemoteXarray
zarr                          intake_xarray.xzarr.ZarrSource
```

A verbose option includes `__file__` locations, potentially useful for untangling issues with environments.
```
$ intake drivers list -v
netcdf                        intake_xarray.netcdf.NetCDFSource @ /home/dallan/Repos/bnl/intake-xarray/intake_xarray/netcdf.py
opendap                       intake_xarray.opendap.OpenDapSource @ /home/dallan/Repos/bnl/intake-xarray/intake_xarray/opendap.py
rasterio                      intake_xarray.raster.RasterIOSource @ /home/dallan/Repos/bnl/intake-xarray/intake_xarray/raster.py
remote-xarray                 intake_xarray.xarray_container.RemoteXarray @ /home/dallan/Repos/bnl/intake-xarray/intake_xarray/xarray_container.py
zarr                          intake_xarray.xzarr.ZarrSource @ /home/dallan/Repos/bnl/intake-xarray/intake_xarray/xzarr.py
```

Now suppose I want to disable the 'zarr'` driver provided by intake_xarray. Perhaps I have a different implementation that I want to use with 'zarr' and I need to avoid the name collision.

```
$ intake drivers disable intake_xarray.xzarr.ZarrSource
$ intake drivers list
netcdf                        intake_xarray.netcdf.NetCDFSource
opendap                       intake_xarray.opendap.OpenDapSource
rasterio                      intake_xarray.raster.RasterIOSource
remote-xarray                 intake_xarray.xarray_container.RemoteXarray
$ python -c "import intake; print('zarr' in intake.registry)"
False
```

I can later re-enable it:

```
$ intake drivers enable intake_xarray.xzarr.ZarrSource
$ python -c "import intake; print('zarr' in intake.registry)"
True
```

The enable/disable state is stored in a separate YAML file for each driver in `~/.intake/drivers.d`, imitating the system used by Jupyter. For backward compatibility, drivers in packages that begin with `intake*` are included in the registry unless they are explicitly disabled. (That is, they need not have _any_ configuration in `~/.intake/drivers.d`.) Drivers in packages with other names can be explicitly enabled:

```
$ intake drivers enable offbrand_catalog.MongoMetadataStoreCatalog
$ intake drivers list
netcdf                        intake_xarray.netcdf.NetCDFSource
opendap                       intake_xarray.opendap.OpenDapSource
rasterio                      intake_xarray.raster.RasterIOSource
remote-xarray                 intake_xarray.xarray_container.RemoteXarray
zarr                          intake_xarray.xzarr.ZarrSource
mongo_metadatastore           offbrand_catalog.MongoMetadataStoreCatalog
```

The `enable` command created the following file at `~/.intake/drivers.d/offbrand_catalog.MongoMetadataStoreCatalog.yml`:

```yaml
offbrand_catalog.MongoMetadataStoreCatalog:                                                                                                                                                   
  enabled: true
```

As [documented by Jupyter](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Automatically-enabling-a-server-extension-and-nbextension), packages can automatically enable their drivers at install time by using `data_files` in `setup.py` to place the corresponding files in `~/.intake/drivers.d/`.