### PR TITLE
Separate out parameter munging

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -10,11 +10,11 @@ datasets, called *catalog entries*.  A catalog entry for a dataset includes info
 
 In addition, Intake allows the arguments to data sources to be templated, with the variables explicitly
 expressed as "user parameters". The given arguments are rendered using ``jinja2`` and the named user
-parameters, and validation is also provided for the allowed types and values for both the template
+parameters. Those parameters are also offer validation of the allowed types and values, for both the template
 values and the final arguments passed to the data source. The parameters are named and described, to
-indicate to the user what they are for.
-This kind of structure can be used to, for example,
-choose between two parts of a given data source, like "latest" and "stable".
+indicate to the user what they are for. This kind of structure can be used to, for example,
+choose between two parts of a given data source, like "latest" and "stable", see the `entry1_part` entry in
+the example below.
 
 
 YAML Format
@@ -45,10 +45,10 @@ Intake catalogs are typically described with YAML files.  Here is an example:
         description: entry1 part
         parameters: # User parameters
           part:
-            description: part of filename
+            description: section of the data
             type: str
-            default: "1"
-            allowed: ["1", "2"]
+            default: "stable"
+            allowed: ["latest", "stable"]
         driver: csv
         args:
           urlpath: '{{ CATALOG_DIR }}/entry1_{{ part }}.csv'
@@ -137,21 +137,19 @@ Templating
 
 Intake catalog files support Jinja2 templating for driver arguments. Any occurrence of
 a substring like ``{{field}}`` will be replaced by the value of the user parameters with
-that same name, or explicitly provided by the user. For how to specify these user parameters,
+that same name, or the value explicitly provided by the user. For how to specify these user parameters,
 see the next section.
 
 Some additional values are available for templating. The following is always available:
-
-- ``CATALOG_DIR``: The full path to the directory containing the YAML catalog file.  This is especially useful
-  for constructing paths relative to the catalog directory to locate data files and custom drivers.
-
-so that the search for CSV files for the two "entry1" blocks, above, will happen in the same directory as
+``CATALOG_DIR``, the full path to the directory containing the YAML catalog file.  This is especially useful
+for constructing paths relative to the catalog directory to locate data files and custom drivers.
+For example, the search for CSV files for the two "entry1" blocks, above, will happen in the same directory as
 where the catalog file was found.
 
 The following functions `may` be available. Since these execute code, the user of a catalog may decide
 whether they trust those functions or not.
 
-- ``env("USER")``: look in the environment for the named variable
+- ``env("USER")``: look in the set environment variables for the named variable
 - ``client_env("USER")``: exactly the same, except that when using a client-server topology, the
   value will come from the environment of the client.
 - ``shell("get_login thisuser -t")``: execute the command, and use the output as the value. The
@@ -189,12 +187,12 @@ A parameter may look as follows:
 
     parameters:
       name:
-        description: human-readable text for what this parameter means
-        type: optional, one of bool, str, int, float, list[str], list[int], list[float], datetime
-        default: optional, value to assume if user does not override
-        allowed: optional, list of values that are OK, for validation
-        min: optional, minimum allowed, for validation
-        max: optional, maximum allowed, for validation
+        description: name to use  # human-readable text for what this parameter means
+        type: str  # optional, one of bool, str, int, float, list[str], list[int], list[float], datetime
+        default: normal  # optional, value to assume if user does not override
+        allowed: ["normal", "strange"]  # optional, list of values that are OK, for validation
+        min: "n"  # optional, minimum allowed, for validation
+        max: "t"  # optional, maximum allowed, for validation
 
 A parameter, not to be confused with an :term:`argument`,
 can have one of two uses:
@@ -209,7 +207,7 @@ can have one of two uses:
   coerced to the given type of the parameter and validated against the allowed/max/min. It is therefore possible
   to use the string templating system (e.g., to get a value from the environment), but pass the final value as,
   for example, an integer. It makes no sense to provide a default for this case (the argument already has a value),
-  but will no raise an exception.
+  but providing a default will not raise an exception.
 
 Note: the ``datetime`` type accepts multiple values:
 Python datetime, ISO8601 string,  Unix timestamp int, "now" and  "today".

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -3,6 +3,11 @@ Glossary
 
 .. glossary::
 
+    Argument
+        One of a set of values passed to a function or class. In the Intake sense, this usually is the
+        set of key-value pairs defined in the "args" section of a source definition; unless the user
+        overrides, these will be used for instantiating the source.
+
     Cache
         Local copies of remote files. Intake allows for download-on-first-use for data-sources,
         so that subsequent access is much faster, see :ref:`caching`. The
@@ -102,6 +107,11 @@ Glossary
 
     TTL
         Time-to-live, how long before the give entity is considered to have expired. Usually in seconds.
+
+    User Parameter
+        A data source definition can contain a "parameters" section, which can act as explicit decision indicators
+        for the user, or as validation and type coersion for the definition's :term:`Argument` s. See
+        :ref:`paramdefs`.
 
     YAML
         A text-based format for expressing data with a dictionary (key-value) and list structure, with a limited

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -146,6 +146,22 @@ and not having to use boilerplate code in each notebook/script that makes use of
 reference one-another, be stored remotely, and include extra metadata such as a set of named quick-look plots that
 are appropriate for the particular data source.
 
+Many catalog entries will also contain "user_parameter" blocks, which are indications of options explicitly
+allowed by the catalog author, or for validation or the values passed. The user can customise how a data
+source is accessed by providing values for the user_parameters, overriding the arguments specified in
+the entry, or passing extra keyword arguments to be passed to the driver. The keywords that should
+be passed are limited to the user_parameters defined and the inputs expected by the specific
+driver - such usage is expected only from those already familiar with the specifics of the given
+format. In the following example, the user overrides the "csv_kwargs" keyword, which is described
+in the documentation for :func:`CSVSource`_ and gets passed down to the CSV reader::
+
+    # pass extra kwargs understood by the csv driver
+    >>> intake.cat.states(csv_kwargs={'header': None, 'skiprows': 1}).read().head()
+               0           1   ...                                17
+    0     Alabama     alabama  ...    https://twitter.com/alabamagov
+    1      Alaska      alaska  ...        https://twitter.com/alaska
+
+
 Note that, if you are *creating* such catalogs, you may well start by trying the ``open_csv`` command,
 above, and then use ``print(ds.yaml())``. If you do this now, you will see that the output is very
 similar to the catalog file we have provided.

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -436,7 +436,7 @@ class RemoteCatalog(Catalog):
         # Include (cached) tab-completable entries and normal attributes.
         return (
             [key for key in self._ipython_key_completions_() if
-             re.match("[_A-Za-z][_a-zA-Z0-9]*$", key)  # valid Python identifer
+             re.match("[_A-Za-z][_a-zA-Z0-9]*$", key)  # valid Python identifier
              and not keyword.iskeyword(key)]  # not a Python keyword
             + list(self.__dict__.keys()))
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -130,9 +130,10 @@ class UserParameter(DictSerialiseMixin):
 class LocalCatalogEntry(CatalogEntry):
     """A catalog entry on the local system
     """
-    def __init__(self, name, description, driver, direct_access, args, cache,
-                 parameters, metadata, catalog_dir, getenv=True,
-                 getshell=True, catalog=None):
+
+    def __init__(self, name, description, driver, direct_access=True, args={},
+                 cache=[], parameters=[], metadata={}, catalog_dir='',
+                 getenv=True, getshell=True, catalog=None):
         """
 
         Parameters
@@ -222,7 +223,9 @@ class LocalCatalogEntry(CatalogEntry):
                   'CATALOG_DIR': self._catalog_dir}
         params.update(self._open_args)
 
-        open_args = merge_pars(params, user_parameters, self._user_parameters)
+        open_args = merge_pars(params, user_parameters, self._user_parameters,
+                               getshell=self.getshell, getenv=self.getenv,
+                               client=False)
 
         if len(self._plugin) == 0:
             raise ValueError('No plugins loaded for this entry: %s\n'

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -92,6 +92,7 @@ class UserParameter(DictSerialiseMixin):
         desc = {
             'name': self.name,
             'description': self.description,
+            # the Parameter might not have a type at all
             'type': self.type or 'unknown',
         }
         for attr in ['min', 'max', 'allowed', 'default']:

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -60,7 +60,7 @@ def test_local_catalog(catalog1):
     assert catalog1['entry1'].get().container == 'dataframe'
     md = catalog1['entry1'].get().metadata
     md.pop('catalog_dir')
-    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    assert md == dict(foo='bar', bar=[1, 2, 3])
 
     # Use default parameters
     assert catalog1['entry1_part'].get().container == 'dataframe'
@@ -290,16 +290,16 @@ def test_union_catalog():
     desc_open['args']['metadata'].pop('catalog_dir')
     assert 'csv' in str(desc_open.pop('plugin'))
     assert desc_open == {
-        'args': {'metadata': {'bar': [2, 4, 6], 'cache': [], 'foo': 'baz'}},
+        'args': {'metadata': {'bar': [2, 4, 6], 'foo': 'baz'}},
         'description': 'entry1 part',
         'direct_access': 'allow',
-        'metadata': {'bar': [2, 4, 6], 'cache': [], 'foo': 'baz'},
+        'metadata': {'bar': [2, 4, 6], 'foo': 'baz'},
     }
 
     # Implied creation of data source
     assert union_cat.entry1.container == 'dataframe'
     md = union_cat.entry1._metadata
-    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    assert md == dict(foo='bar', bar=[1, 2, 3])
 
     # Use default parameters in explict creation of data source
     assert union_cat.entry1_part().container == 'dataframe'

--- a/intake/catalog/tests/test_parameters.py
+++ b/intake/catalog/tests/test_parameters.py
@@ -166,3 +166,16 @@ def test_extra_arg():
     e = LocalCatalogEntry('', '', driver, args={'arg1': "oi"})
     s = e(arg2='extra')
     assert s.kwargs['arg2'] == 'extra'
+
+
+def test_unknown():
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"})
+    s = e()
+    assert s.kwargs['arg1'] == ""
+
+    # parameter has no default
+    up = UserParameter('name')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up])
+    s = e()
+    assert s.kwargs['arg1'] == ""

--- a/intake/catalog/tests/test_parameters.py
+++ b/intake/catalog/tests/test_parameters.py
@@ -1,0 +1,138 @@
+import os
+import pytest
+from intake.catalog.local import LocalCatalogEntry, UserParameter
+from intake.source.base import DataSource
+
+
+class NoSource(DataSource):
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+driver = 'intake.catalog.tests.test_parameters.NoSource'
+
+
+def test_simplest():
+    e = LocalCatalogEntry('', '', driver, args={'arg1': 1})
+    s = e()
+    assert s.kwargs['arg1'] == 1
+
+
+def test_parameter_default():
+    up = UserParameter('name', default='oi')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up])
+    s = e()
+    assert s.kwargs['arg1'] == 'oi'
+
+
+def test_maybe_par_env():
+    up = UserParameter('name', default='env(INTAKE_TEST_VAR)')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up], getenv=False)
+    s = e()
+    assert s.kwargs['arg1'] == 'env(INTAKE_TEST_VAR)'
+
+    os.environ['INTAKE_TEST_VAR'] = 'oi'
+    up = UserParameter('name', default='env(INTAKE_TEST_VAR)')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up])
+    s = e()
+    assert s.kwargs['arg1'] == 'oi'
+
+    del os.environ['INTAKE_TEST_VAR']
+
+    s = e()
+    assert s.kwargs['arg1'] == ''
+
+
+def test_up_averride():
+    up = UserParameter('name', default='env(INTAKE_TEST_VAR)')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up], getenv=False)
+    s = e(name='other')
+    assert s.kwargs['arg1'] == 'other'
+
+
+def test_override():
+    up = UserParameter('name', default='env(INTAKE_TEST_VAR)')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up], getenv=False)
+    s = e(arg1='other')
+    assert s.kwargs['arg1'] == 'other'
+
+
+def test_auto_env():
+    os.environ['INTAKE_TEST_VAR'] = 'oi'
+    e = LocalCatalogEntry('', '', driver,
+                          args={'arg1': "{{env(INTAKE_TEST_VAR)}}"},
+                          parameters=[], getenv=True)
+    s = e()
+    assert s.kwargs['arg1'] == 'oi'
+
+    del os.environ['INTAKE_TEST_VAR']
+
+    s = e()
+    assert s.kwargs['arg1'] == ''
+
+    e = LocalCatalogEntry('', '', driver,
+                          args={'arg1': "{{env(INTAKE_TEST_VAR)}}"},
+                          parameters=[], getenv=False)
+    s = e()
+    assert s.kwargs['arg1'] == '{{env(INTAKE_TEST_VAR)}}'
+
+
+def test_validate_up():
+    up = UserParameter('name', default=1, type='int')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up], getenv=False)
+    e()  # OK
+    with pytest.raises(ValueError):
+        e(name='oi')
+
+    up = UserParameter('name', type='int')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"},
+                          parameters=[up], getenv=False)
+    s = e()  # OK
+    assert s.kwargs['arg1'] == '0'  # default default for int
+
+
+def test_validate_par():
+    up = UserParameter('arg1', type='int')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "oi"},
+                          parameters=[up], getenv=False)
+    with pytest.raises(ValueError):
+        e()
+    e = LocalCatalogEntry('', '', driver, args={'arg1': 1},
+                          parameters=[up], getenv=False)
+    e()  # OK
+
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "1"},
+                          parameters=[up], getenv=False)
+    s = e()  # OK
+    assert s.kwargs['arg1'] == 1  # a number, not str
+
+
+def test_overrides():
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "oi"})
+    s = e(arg1='hi')
+    assert s.kwargs['arg1'] == 'hi'
+
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "{{name}}"})
+    s = e(name='hi')
+    assert s.kwargs['arg1'] == 'hi'
+
+    os.environ['INTAKE_TEST_VAR'] = 'another'
+    e = LocalCatalogEntry('', '', driver, args={'arg1': "oi"})
+    s = e(arg1='{{env(INTAKE_TEST_VAR)}}')
+    assert s.kwargs['arg1'] == 'another'
+
+    up = UserParameter('arg1', type='int')
+    e = LocalCatalogEntry('', '', driver, args={'arg1': 1},
+                          parameters=[up])
+    with pytest.raises(ValueError):
+        e(arg1='oi')
+
+    s = e(arg1='1')
+    assert s.kwargs['arg1'] == 1

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -128,7 +128,7 @@ def test_read(intake_server):
 
     md = d.metadata.copy()
     md.pop('catalog_dir', None)
-    assert md == dict(foo='bar', bar=[1, 2, 3], cache=[])
+    assert md == dict(foo='bar', bar=[1, 2, 3])
 
     df = d.read()
 
@@ -153,11 +153,11 @@ def test_read_direct(intake_server):
     assert info['shape'] == (None, 3)  # Do not know CSV size ahead of time
     md = info['metadata'].copy()
     md.pop('catalog_dir', None)
-    assert md == {'bar': [2, 4, 6], 'foo': 'baz', 'cache': []}
+    assert md == {'bar': [2, 4, 6], 'foo': 'baz'}
 
     md = d.metadata.copy()
     md.pop('catalog_dir', None)
-    assert md == dict(foo='baz', bar=[2, 4, 6], cache=[])
+    assert md == dict(foo='baz', bar=[2, 4, 6])
     assert d.description == 'entry1 part'
     df = d.read()
 

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -115,7 +115,7 @@ class TestServerV1Source(TestServerV1Base):
         self.assertEqual(resp_msg['npartitions'], 2)
         md = resp_msg['metadata']
         md.pop('catalog_dir', None)
-        self.assertEqual(md, dict(foo='bar', bar=[1, 2, 3], cache=[]))
+        self.assertEqual(md, dict(foo='bar', bar=[1, 2, 3]))
 
         self.assertTrue(isinstance(resp_msg['source_id'], str))
 
@@ -130,7 +130,7 @@ class TestServerV1Source(TestServerV1Base):
         self.assertTrue(args['urlpath'].endswith('/entry1_2.csv'))
         md = args['metadata']
         md.pop('catalog_dir', None)
-        self.assertEqual(md, dict(foo='baz', bar=[2, 4, 6], cache=[]))
+        self.assertEqual(md, dict(foo='baz', bar=[2, 4, 6]))
         self.assertEqual(resp_msg['description'], 'entry1 part')
 
     def test_read_part_compressed(self):

--- a/intake/container/persist.py
+++ b/intake/container/persist.py
@@ -39,6 +39,7 @@ class PersistStore(YAMLFileCatalog):
     _singleton = [None]
 
     def __new__(cls, *args, **kwargs):
+        # singleton pattern: only one instance will ever exist
         if cls._singleton[0] is None:
             o = object.__new__(cls)
             o._captured_init_args = args

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -14,5 +14,5 @@ else
     conda install -y --use-local intake
 
     echo "Running unit tests."
-    py.test
+    py.test --cov=intake
 fi

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -14,5 +14,5 @@ else
     conda install -y --use-local intake
 
     echo "Running unit tests."
-    py.test --cov=intake
+    py.test
 fi

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    python_requires=">=3.5",
+    python_requires=">=2.5",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     zip_safe=False,


### PR DESCRIPTION
Makes parameter evaluation clearer, and allows for user override of
any source input, with optional validation

Fixes #257 