### PR TITLE
Get catalog names from several inputs

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -50,9 +50,9 @@ class Catalog(DataSource):
     container = 'catalog'
     name = 'catalog'
 
-    def __init__(self, *args, name=None, metadata=None, auth=None, ttl=1,
-                 getenv=True, getshell=True, persist_mode='default',
-                 storage_options=None):
+    def __init__(self, *args, name=None, description=None, metadata=None,
+                 auth=None, ttl=1, getenv=True, getshell=True,
+                 persist_mode='default', storage_options=None):
         """
         Parameters
         ----------
@@ -60,6 +60,9 @@ class Catalog(DataSource):
             A single URI or list of URIs.
         name : str, optional
             Unique identifier for catalog. This is primarily useful when
+            manually constructing a catalog. Defaults to None.
+        description : str, optional
+            Description of the catalog. This is primarily useful when
             manually constructing a catalog. Defaults to None.
         metadata: dict
             Additional information about this data
@@ -86,6 +89,7 @@ class Catalog(DataSource):
         """
         super(Catalog, self).__init__()
         self.name = name
+        self.description = description
         self.metadata = metadata or {}
         self.ttl = ttl
         self.getenv = getenv

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -59,11 +59,11 @@ class Catalog(DataSource):
         args : str or list(str)
             A single URI or list of URIs.
         name : str, optional
-            Unique identifier for catalog. This is primarily useful when
-            manually constructing a catalog. Defaults to None.
+            Unique identifier for catalog. This takes precedence over whatever
+            is stated in the cat file itself. Defaults to None.
         description : str, optional
-            Description of the catalog. This is primarily useful when
-            manually constructing a catalog. Defaults to None.
+            Description of the catalog. This takes precedence over whatever
+            is stated in the cat file itself. Defaults to None.
         metadata: dict
             Additional information about this data
         auth : BaseClientAuth or None

--- a/intake/catalog/default.py
+++ b/intake/catalog/default.py
@@ -80,7 +80,7 @@ def load_combo_catalog():
     """Load a union of the user and global catalogs for convenience"""
     user_dir = user_data_dir()
     global_dir = global_data_dir()
-
+    desc = 'Generated from data packages found on your intake search path'
     cat_dirs = []
     if os.path.isdir(user_dir):
         cat_dirs.append(user_dir + '/*.yaml')
@@ -96,4 +96,4 @@ def load_combo_catalog():
             else:
                 cat_dirs.append(path_dir)
 
-    return YAMLFilesCatalog(cat_dirs, name='builtin')
+    return YAMLFilesCatalog(cat_dirs, name='builtin', description=desc)

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -138,7 +138,9 @@ class LocalCatalogEntry(CatalogEntry):
         Parameters
         ----------
         name: str
-            How this entry is known, normally from its key in a YAML file
+            How this entry is known, normally from its key in a YAML file, or
+            if that is not provided then from name of file, or name of dir if
+            file name is 'catalog.yaml' or 'catalog.yml'.
         description: str
             Brief text about the target source
         driver: str

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -228,7 +228,7 @@ class LocalCatalogEntry(CatalogEntry):
 
         if len(self._plugin) == 0:
             raise ValueError('No plugins loaded for this entry: %s\n'
-                             'A listing of installable plugins can be found ' 
+                             'A listing of installable plugins can be found '
                              'at https://intake.readthedocs.io/en/latest/plugin'
                              '-directory.html .'
                              % self._driver)
@@ -491,7 +491,8 @@ class CatalogParser(object):
         return dict(
             plugin_sources=self._parse_plugins(data),
             data_sources=self._parse_data_sources(data),
-            metadata=data.get('metadata', {})
+            metadata=data.get('metadata', {}),
+            name=data.get('name'),
         )
 
 
@@ -552,8 +553,6 @@ class YAMLFileCatalog(Catalog):
             file_open = open_files(self.path, mode='rb', **options)
             assert len(file_open) == 1
             file_open = file_open[0]
-        self.name = os.path.splitext(os.path.basename(
-            self.path))[0].replace('.', '_')
         self._dir = get_dir(self.path)
 
         with file_open as f:
@@ -584,7 +583,14 @@ class YAMLFileCatalog(Catalog):
             self._entries[entry.name] = entry
 
         self.metadata = cfg.get('metadata', {})
+        self.name = self.name or cfg.get('name') or self.name_from_path
 
+    @property
+    def name_from_path(self):
+        name = os.path.splitext(os.path.basename(self.path))[0]
+        if name == 'catalog':
+            name = os.path.basename(os.path.dirname(self.path))
+        return name.replace('.', '_')
 
 global_registry['yaml_file_cat'] = YAMLFileCatalog
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -493,6 +493,7 @@ class CatalogParser(object):
             data_sources=self._parse_data_sources(data),
             metadata=data.get('metadata', {}),
             name=data.get('name'),
+            description=data.get('description'),
         )
 
 
@@ -584,6 +585,7 @@ class YAMLFileCatalog(Catalog):
 
         self.metadata = cfg.get('metadata', {})
         self.name = self.name or cfg.get('name') or self.name_from_path
+        self.description = self.description or cfg.get('description')
 
     @property
     def name_from_path(self):
@@ -629,14 +631,16 @@ class YAMLFilesCatalog(Catalog):
         if isinstance(self.path, (list, tuple)):
             files = sum([open_files(p, mode='rb', **options)
                          for p in self.path], [])
-            self.name = "%i files" % len(files)
+            self.name = self.name or "%i files" % len(files)
+            self.description = self.description or f'Catalog generated from {len(files)} files'
             self.path = [make_path_posix(p) for p in self.path]
         else:
             if isinstance(self.path, str) and '*' not in self.path:
                 self.path = self.path + '/*'
             files = open_files(self.path, mode='rb', **options)
             self.path = make_path_posix(self.path)
-            self.name = self.path
+            self.name = self.name or self.path
+            self.description = self.description or f'Catalog generated from all files found in {self.path}'
         if not set(f.path for f in files) == set(
                 f.path for f in self._cat_files):
             # glob changed, reload all

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -589,6 +589,7 @@ class YAMLFileCatalog(Catalog):
 
     @property
     def name_from_path(self):
+        """If catalog is named 'catalog' take name from parent directory"""
         name = os.path.splitext(os.path.basename(self.path))[0]
         if name == 'catalog':
             name = os.path.basename(os.path.dirname(self.path))

--- a/intake/catalog/tests/catalog.yml
+++ b/intake/catalog/tests/catalog.yml
@@ -1,0 +1,8 @@
+plugins:
+  source:
+    - module: intake.catalog.tests.example1_source
+sources:
+  use_example1:
+    description: example1 source plugin
+    driver: example1
+    args: {}

--- a/intake/catalog/tests/catalog1.yml
+++ b/intake/catalog/tests/catalog1.yml
@@ -1,3 +1,4 @@
+name: name_in_cat
 metadata:
   test: true
 plugins:

--- a/intake/catalog/tests/catalog_named.yml
+++ b/intake/catalog/tests/catalog_named.yml
@@ -1,4 +1,5 @@
 name: name_in_spec
+description: This is a catalog with a description in the yaml
 plugins:
   source:
     - module: intake.catalog.tests.example1_source

--- a/intake/catalog/tests/catalog_named.yml
+++ b/intake/catalog/tests/catalog_named.yml
@@ -1,0 +1,9 @@
+name: name_in_spec
+plugins:
+  source:
+    - module: intake.catalog.tests.example1_source
+sources:
+  use_example1:
+    description: example1 source plugin
+    driver: example1
+    args: {}

--- a/intake/catalog/tests/catalog_named.yml
+++ b/intake/catalog/tests/catalog_named.yml
@@ -1,5 +1,7 @@
 name: name_in_spec
 description: This is a catalog with a description in the yaml
+metadata:
+  some: thing
 plugins:
   source:
     - module: intake.catalog.tests.example1_source

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -433,6 +433,7 @@ def test_cat_with_declared_name():
     cat = open_catalog(fn, name='name_in_func', description=description)
     assert cat.name == 'name_in_func'
     assert cat.description == description
+    assert cat.metadata.get('some') == 'thing'
 
     cat = open_catalog(fn)
     assert cat.name == 'name_in_spec'

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -413,24 +413,41 @@ def test_multi_cat_names():
     fn2 = abspath("catalog_union_2.yml")
     cat = open_catalog([fn1, fn2])
     assert cat.name == '2 files'
+    assert cat.description == 'Catalog generated from 2 files'
+
+    cat = open_catalog([fn1, fn2], name='special_name',
+                       description='Special description')
+    assert cat.name == 'special_name'
+    assert cat.description == 'Special description'
+
+
+def test_name_of_builtin():
+    import intake
+    assert intake.cat.name == 'builtin'
+    assert intake.cat.description == 'Generated from data packages found on your intake search path'
 
 
 def test_cat_with_declared_name():
     fn = abspath("catalog_named.yml")
-    cat = open_catalog(fn, name='name_in_func')
+    description = 'Description declared in the open function'
+    cat = open_catalog(fn, name='name_in_func', description=description)
     assert cat.name == 'name_in_func'
+    assert cat.description == description
 
     cat = open_catalog(fn)
     assert cat.name == 'name_in_spec'
+    assert cat.description == 'This is a catalog with a description in the yaml'
 
 
 def test_cat_with_no_declared_name_gets_name_from_dir_if_file_named_catalog():
     fn = abspath("catalog.yml")
-    cat = open_catalog(fn, name='name_in_func')
+    cat = open_catalog(fn, name='name_in_func', description='Description in func')
     assert cat.name == 'name_in_func'
+    assert cat.description == 'Description in func'
 
     cat = open_catalog(fn)
     assert cat.name == 'tests'
+    assert cat.description == None
 
 
 def test_default_expansions():

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -79,6 +79,13 @@ def test_nested(catalog1):
     assert catalog1.nested.nested.nested().cat.cat.cat is catalog1
 
 
+def test_nested_gets_name_from_super(catalog1):
+    assert catalog1.name == 'name_in_cat'
+    assert 'nested' in catalog1
+    nested = catalog1.nested
+    assert nested.name == 'nested'
+
+
 def test_hash(catalog1):
     assert catalog1.nested() == catalog1.nested.nested()
 

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -84,6 +84,7 @@ def test_nested_gets_name_from_super(catalog1):
     assert 'nested' in catalog1
     nested = catalog1.nested
     assert nested.name == 'nested'
+    assert nested().name == 'nested'
 
 
 def test_hash(catalog1):

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -408,6 +408,24 @@ def test_multi_cat_names():
     assert cat.name == '2 files'
 
 
+def test_cat_with_declared_name():
+    fn = abspath("catalog_named.yml")
+    cat = open_catalog(fn, name='name_in_func')
+    assert cat.name == 'name_in_func'
+
+    cat = open_catalog(fn)
+    assert cat.name == 'name_in_spec'
+
+
+def test_cat_with_no_declared_name_gets_name_from_dir_if_file_named_catalog():
+    fn = abspath("catalog.yml")
+    cat = open_catalog(fn, name='name_in_func')
+    assert cat.name == 'name_in_func'
+
+    cat = open_catalog(fn)
+    assert cat.name == 'tests'
+
+
 def test_default_expansions():
     try:
         os.environ['INTAKE_INT_TEST'] = '1'

--- a/intake/gui/tests/test_gui.py
+++ b/intake/gui/tests/test_gui.py
@@ -15,5 +15,5 @@ def test_add_cat():
     import intake
     intake.gui.add_cat(os.path.join(here, '..', '..', 'catalog', 'tests',
                                     'catalog1.yml'))
-    assert 'catalog1' in intake.gui.cat_list.value
+    assert 'name_in_cat' in intake.gui.cat_list.value
     assert 'entry1' in intake.gui.item_list.options


### PR DESCRIPTION
Fixes #305 

Target is to implement naming from:

 1. name given by open function `intake.open_catalog(fn, name='top_priority')`
 2. name given in the spec
 3. name given by the caller, e.g., the entry name of the super cat
 4. name of the file/directory or something else derived from the path
