### PR TITLE
Add items() function to catalog

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -191,6 +191,10 @@ class Catalog(DataSource):
             out[n] = item
         return out
 
+    def items(self):
+        """Get an iterator over (key, value) tuples for the catalog entries."""
+        return self._get_entries().items()
+
     @reload_on_change
     def _get_entry(self, name):
         entry = self._entries[name]

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -67,6 +67,10 @@ def test_local_catalog(catalog1):
     # Specify parameters
     assert catalog1['entry1_part'].get(part='2').container == 'dataframe'
 
+def test_get_items(catalog1):
+    for key,entry in catalog1.items():
+        assert catalog1[key].describe() == entry.describe()
+
 
 def test_nested(catalog1):
     assert 'nested' in catalog1


### PR DESCRIPTION
Between the `__getitem__` access and the `__iter__` implementation, catalogs feel very dictionary-esque (not to mention the internal implementation). I found myself wanting an easier way to iterate over the entries of the catalog in a similar way to dictionaries. Would there be interest in this functionality?