### PR TITLE
DOC: Document what _make_entries_container should return.

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -355,7 +355,7 @@ class Entries(collections.abc.Mapping):
                 return source
 
     def __len__(self):
-        return len(self.catalog)
+        return len(self._catalog)
 
 
 class RemoteCatalog(Catalog):

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -116,7 +116,24 @@ class Catalog(DataSource):
     def _make_entries_container(self):
         """Subclasses may override this to return some other dict-like.
 
-        See RemoteCatalog below for the motivating example for this hook.
+        See RemoteCatalog below for the motivating example for this hook. This
+        is typically useful for large Catalogs backed by dynamic resources such
+        as databases.
+
+        The object returned by this method must implement:
+
+        * ``__iter__()`` -> an iterator of entry names
+        * ``__getitem__(key)`` -> an Entry
+        * ``items()`` -> an iterator of ``(key, Entry)`` pairs
+
+        For best performance the object should also implement:
+
+        * ``__len__()`` -> int
+        * ``__contains__(key)`` -> boolean
+
+        In ``__len__`` or ``__contains__`` are not implemented, intake will
+        fall back on iterating through the entire catalog to compute its length
+        or check for containment, which may be expensive on large catalogs.
         """
         return {}
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -284,7 +284,7 @@ class Catalog(DataSource):
         pass
 
 
-class Entries(dict):
+class Entries:
     """Fetches entries from server on item lookup and iteration.
 
     This fetches pages of entries from the server during iteration and


### PR DESCRIPTION
This documents which parts of the ``dict`` interface we require and why.

Also, I have since learned that inheriting from ``dict`` is still a fraught.
Exactly which methods call which other methods internally changed on a minor
release of Python (see https://github.com/matplotlib/matplotlib/issues/12601).
It's safer for us to implement exactly the methods use and let an
``AttributeError`` be raised if some part of the code starts to use a method we
don't implement, rather than return a wrong value.