### PR TITLE
Give BasicClientAuth a stable dask token.

### DIFF
--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -66,7 +66,15 @@ class BaseClientAuth(object):
         self.args = args
 
     def __dask_tokenize__(self):
-        return self.args
+        return hash(self)
+
+    @property
+    def _tok(self):
+        from dask.base import tokenize
+        return tokenize({'cls': type(self).__name__, 'args': self.args})
+
+    def __hash__(self):
+        return int(self._tok, 16)
 
     def get_headers(self):
         """Returns a dictionary of HTTP headers for the remote catalog request.

--- a/intake/auth/base.py
+++ b/intake/auth/base.py
@@ -65,6 +65,9 @@ class BaseClientAuth(object):
     def __init__(self, *args):
         self.args = args
 
+    def __dask_tokenize__(self):
+        return self.args
+
     def get_headers(self):
         """Returns a dictionary of HTTP headers for the remote catalog request.
         """

--- a/intake/auth/secret.py
+++ b/intake/auth/secret.py
@@ -60,6 +60,7 @@ class SecretClientAuth(BaseClientAuth):
     def __init__(self, secret, key='intake-secret'):
         self.secret = secret
         self.key = key
+        super(SecretClientAuth, self).__init__()
 
     def get_headers(self):
         return {self.key: self.secret}


### PR DESCRIPTION
Catalogs should have a stable `__hash__`. This means they should return a stable
result when

```py
dask.base.tokenize(catalog.__getstate__())
```

is called. In my Catalog subclasses, ``self.auth`` (a ``BaseClientAuth`` instance)
is among the contents of ``__getstate__()``. Dask falls back to its last resort
for tokenization, which is UUID4 and thus not stable.

Implementing `__dask_tokenize__` on `BaseClientAuth` seems the best place to fix
this so that it does not trip up others. Of course I could implement it on my
`Catalog` subclasses instead or as well.