### PR TITLE
More flexibility with dotted nested entry names

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -249,14 +249,27 @@ class Catalog(DataSource):
             return e
         if isinstance(key, str) and '.' in key:
             key = key.split('.')
-        if isinstance(key, (tuple, list)):
-            if len(key) > 1 and key[0] in self._entries:
-                out = self._entries[key[0]].__getitem__(key[1:])
-                return out
-            if len(key) == 1:
-                return self[key[0]]
-        else:
-            raise KeyError(key)
+        if isinstance(key, list):
+            parts = list(key)[:]
+            prefix = ''
+            while parts:
+                bit = parts.pop(0)
+                prefix = prefix + ('.' if prefix else '') + bit
+                if prefix in self._entries:
+                    rest = '.'.join(parts)
+                    try:
+                        out = self._entries[prefix][rest]
+                        return out
+                    except KeyError:
+                        # name conflict like "thing" and "think.oi", where it's
+                        # the latter we are after
+                        continue
+        elif isinstance(key, tuple):
+            out = self
+            for part in key:
+                out = self[part]
+            return out
+        raise KeyError(key)
 
     def discover(self):
         return {"container": 'catalog', 'shape': None,

--- a/intake/catalog/tests/dot-nest.yaml
+++ b/intake/catalog/tests/dot-nest.yaml
@@ -1,0 +1,25 @@
+sources:
+  self:
+    description: this cat
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/dot-nest.yaml"
+  selfdot.dot:
+    description: this cat
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/dot-nest.yaml"
+  self.dot:
+    description: this cat
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/dot-nest.yaml"
+  leaf:
+    description: leaf
+    driver: csv
+  leafdot.dot:
+    description: leaf-dot
+    driver: csv
+  leaf.dot:
+    description: leaf-dot
+    driver: csv

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -531,3 +531,18 @@ def test_getitem_and_getattr():
     assert catalog.tables0 is catalog['tables0']
     assert isinstance(catalog.tables0, LocalCatalogEntry)
     assert isinstance(catalog.metadata, (dict, type(None)))
+
+
+def test_dot_names():
+    fn = abspath('dot-nest.yaml')
+    cat = open_catalog(fn)
+    assert cat.self.leaf._description == 'leaf'
+    assert cat.self['leafdot.dot']._description == 'leaf-dot'
+    assert cat['selfdot.dot', 'leafdot.dot']._description == 'leaf-dot'
+
+    assert cat['self.selfdot.dot', 'leafdot.dot']._description == 'leaf-dot'
+    assert cat['self.self.dot', 'leafdot.dot']._description == 'leaf-dot'
+    assert cat['self.self.dot', 'leaf']._description == 'leaf'
+    assert cat['self.self.dot', 'leaf.dot']._description == 'leaf-dot'
+
+    assert cat['self.self.dot.leaf.dot']._description == 'leaf-dot'


### PR DESCRIPTION
Fixes #316 

@naomi-henderson , @rabernat , please see the list of assertions in the new test and the included catalog file, to see if this now works in the way that you would like to see.

Note that, as with pandas, this complex dotted-name usage will work with getitem style, but not getattr, because of python syntax mangling. It would be possible, and already was, to mix `cat.thing['sub.thing'].more`, but that seems like poor style.