### PR TITLE
revert odd change to required python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,10 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
-    python_requires=">=2.5",
+    python_requires=">=3.6",
     long_description=open('README.md').read(),
     long_description_content_type="text/markdown",
     zip_safe=False,


### PR DESCRIPTION
exclude py2 again, and even py35?