### PR TITLE
Better repr

### DIFF
--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -28,7 +28,8 @@ class CatalogEntry(DictSerialiseMixin):
         """Get a dictionary of attributes of this entry.
 
         Returns: dict with keys
-
+          name: str
+              The name of the catalog entry.
           container : str
               kind of container used by this data source
           description : str
@@ -133,7 +134,7 @@ class CatalogEntry(DictSerialiseMixin):
             'application/json': contents,
             'text/plain': pretty_describe(contents)
         }, metadata={
-            'application/json': { 'root': self._name }
+            'application/json': { 'root': contents["name"]}
         }, raw=True)
         if warning:
             display(warning) # noqa: F821
@@ -145,7 +146,7 @@ class CatalogEntry(DictSerialiseMixin):
         try:
             contents.update(self.describe_open())
         except ValueError:
-            warning = f'Need additional plugin to use {self._driver} driver'
+            warning = f'Need an additional plugin to load {contents["name"]}.'
         return contents, warning
 
     def __getattr__(self, attr):

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -129,14 +129,14 @@ class CatalogEntry(DictSerialiseMixin):
     def _ipython_display_(self):
         """Display the entry as a rich object in an IPython session."""
         contents, warning = self._display_content()
-        display({
+        display({ # noqa: F821
             'application/json': contents,
             'text/plain': pretty_describe(contents)
         }, metadata={
             'application/json': { 'root': self.name }
         }, raw=True)
         if warning:
-            display(warning)
+            display(warning) # noqa: F821
 
     def _display_content(self):
         """Create a dictionary with content to display in reprs."""

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -144,10 +144,6 @@ class CatalogEntry(DictSerialiseMixin):
         warning = None
         try:
             contents.update(self.describe_open())
-            if 'plots' in contents['metadata']:
-                contents['metadata'].pop('plots')
-            if 'plots' in contents['args'].get('metadata', {}):
-                contents['args']['metadata'].pop('plots')
         except ValueError:
             warning = f'Need additional plugin to use {self._driver} driver'
         return contents, warning

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -133,7 +133,7 @@ class CatalogEntry(DictSerialiseMixin):
             'application/json': contents,
             'text/plain': pretty_describe(contents)
         }, metadata={
-            'application/json': { 'root': self.name }
+            'application/json': { 'root': self._name }
         }, raw=True)
         if warning:
             display(warning) # noqa: F821

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -149,7 +149,7 @@ class CatalogEntry(DictSerialiseMixin):
             if 'plots' in contents['args'].get('metadata', {}):
                 contents['args']['metadata'].pop('plots')
         except ValueError:
-            warning = f'Need additional plugin to use {self.source._driver} driver'
+            warning = f'Need additional plugin to use {self._driver} driver'
         return contents, warning
 
     def __getattr__(self, attr):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -207,6 +207,7 @@ class LocalCatalogEntry(CatalogEntry):
     def describe(self):
         """Basic information about this entry"""
         return {
+            'name': self._name,
             'container': self._container,
             'description': self._description,
             'direct_access': self._direct_access,
@@ -253,6 +254,7 @@ class LocalCatalogEntry(CatalogEntry):
     def describe_open(self, **user_parameters):
         _, args = self._create_open_args(user_parameters)
         return {
+            'container': self._container,
             'plugin': self._driver,
             'description': self._description,
             'direct_access': self._direct_access,

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -650,3 +650,23 @@ def test_no_instance():
 
     # this would error on instantiation with driver not found
     assert e0 != e1
+
+
+def test_display_content(catalog1):
+    entry = catalog1['arr']
+    content, warning = entry._display_content()
+    content['args']['metadata'].pop('catalog_dir') # remove os-dependent paths
+    content['args'].pop('path') # remove os-dependent paths
+    assert warning == None
+    assert content == {
+        'container': 'ndarray',
+        'description': 'small array',
+        'direct_access': 'forbid',
+        'user_parameters': [],
+        'plugin': 'numpy',
+        'metadata': {},
+        'args': {
+            'metadata': {},
+            'chunks': 5
+        }
+    }

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -659,6 +659,7 @@ def test_display_content(catalog1):
     content['args'].pop('path') # remove os-dependent paths
     assert warning == None
     assert content == {
+        'name': 'arr',
         'container': 'ndarray',
         'description': 'small array',
         'direct_access': 'forbid',

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -38,12 +38,14 @@ def test_local_catalog(catalog1):
                        ['use_example1', 'nested', 'entry1', 'entry1_part',
                         'remote_env', 'local_env', 'text', 'arr'])
     assert catalog1['entry1'].describe() == {
+        'name': 'entry1',
         'container': 'dataframe',
         'direct_access': 'forbid',
         'user_parameters': [],
         'description': 'entry1 full'
     }
     assert catalog1['entry1_part'].describe() == {
+        'name': 'entry1_part',
         'container': 'dataframe',
         'user_parameters': [
             {
@@ -286,6 +288,7 @@ def test_union_catalog():
     assert_items_equal(list(union_cat), ['entry1', 'entry1_part', 'use_example1'])
 
     assert union_cat.entry1_part.describe() == {
+        'name': 'entry1_part',
         'container': 'dataframe',
         'user_parameters': [
             {
@@ -308,6 +311,7 @@ def test_union_catalog():
     assert desc_open == {
         'args': {'metadata': {'bar': [2, 4, 6], 'foo': 'baz'}},
         'description': 'entry1 part',
+        'container': 'dataframe',
         'direct_access': 'allow',
         'metadata': {'bar': [2, 4, 6], 'foo': 'baz'},
     }

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -433,6 +433,7 @@ def test_display_content(intake_server):
     content['args'].pop('path') # remove os-dependent paths
     assert warning == None
     assert content == {
+        'name': 'arr',
         'container': 'ndarray',
         'description': 'small array',
         'direct_access': 'forbid',

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -429,8 +429,6 @@ def test_display_content(intake_server):
     remote_catalog = Catalog(intake_server)
     entry = remote_catalog['arr']
     content, warning = entry._display_content()
-    content['args']['metadata'].pop('catalog_dir') # remove os-dependent paths
-    content['args'].pop('path') # remove os-dependent paths
     assert warning == None
     assert content == {
         'name': 'arr',
@@ -438,10 +436,7 @@ def test_display_content(intake_server):
         'description': 'small array',
         'direct_access': 'forbid',
         'user_parameters': [],
-        'plugin': 'numpy',
+        'plugin': None,
         'metadata': {},
-        'args': {
-            'metadata': {},
-            'chunks': 5
-        }
+        'args': ('http://localhost:7483/',)
     }

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -424,3 +424,23 @@ def test_len(intake_server):
     remote_catalog = Catalog(intake_server)
     local_catalog = Catalog(TEST_CATALOG_PATH)
     assert sum(1 for entry in local_catalog) == len(remote_catalog)
+
+def test_display_content(intake_server):
+    remote_catalog = Catalog(intake_server)
+    entry = remote_catalog['arr']
+    content, warning = entry._display_content()
+    content['args']['metadata'].pop('catalog_dir') # remove os-dependent paths
+    content['args'].pop('path') # remove os-dependent paths
+    assert warning == None
+    assert content == {
+        'container': 'ndarray',
+        'description': 'small array',
+        'direct_access': 'forbid',
+        'user_parameters': [],
+        'plugin': 'numpy',
+        'metadata': {},
+        'args': {
+            'metadata': {},
+            'chunks': 5
+        }
+    }

--- a/intake/cli/client/tests/test_local_integration.py
+++ b/intake/cli/client/tests/test_local_integration.py
@@ -34,7 +34,7 @@ def test_full_list():
     out, _ = process.communicate()
     out = out.decode('utf-8')
 
-    assert len(out.strip().split('\n')) == 12
+    assert len(out.strip().split('\n')) == 15
     assert "[entry1]" in out
     assert "[entry1_part]" in out
     assert "[use_example1]" in out
@@ -51,6 +51,7 @@ def test_describe():
 [entry1] container=dataframe
 [entry1] description=entry1 full
 [entry1] direct_access=forbid
+[entry1] name=entry1
 [entry1] user_parameters=[]
 """
 

--- a/intake/gui/source_view.py
+++ b/intake/gui/source_view.py
@@ -76,6 +76,10 @@ class Description(Base):
         if not self._source:
             return ' ' * 100  # HACK - make sure that area is big
         contents, warning = self.source._display_content()
+        if 'metadata' in contents and 'plots' in contents['metadata']:
+            contents['metadata'].pop('plots')
+        if 'args' in contents and 'plots' in contents['args'].get('metadata', {}):
+            contents['args']['metadata'].pop('plots')
         return pretty_describe(contents) + ('\n' + warning if warning else '')
 
     @property

--- a/intake/gui/source_view.py
+++ b/intake/gui/source_view.py
@@ -9,14 +9,6 @@ from .base import Base
 from ..utils import pretty_describe
 
 
-def pretty_describe(object, nestedness=0, indent=2):
-    """Maintain dict ordering - but make string version prettier"""
-    if not isinstance(object, dict):
-        return str(object)
-    sep = f'\n{" " * nestedness * indent}'
-    return sep.join((f'{k}: {pretty_describe(v, nestedness + 1)}' for k, v in object.items()))
-
-
 class Description(Base):
     """
     Class for displaying a textual description of a data source.

--- a/intake/gui/source_view.py
+++ b/intake/gui/source_view.py
@@ -4,10 +4,9 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from copy import deepcopy
-
 import panel as pn
 from .base import Base
+from ..utils import pretty_describe
 
 
 def pretty_describe(object, nestedness=0, indent=2):
@@ -76,18 +75,8 @@ class Description(Base):
         """String representation of the source's description"""
         if not self._source:
             return ' ' * 100  # HACK - make sure that area is big
-        contents = deepcopy(self.source.describe())
-        try:
-            extra = deepcopy(self.source.describe_open())
-            contents.update(extra)
-            if 'plots' in contents['metadata']:
-                contents['metadata'].pop('plots')
-            if 'plots' in contents['args'].get('metadata', {}):
-                contents['args']['metadata'].pop('plots')
-            return pretty_describe(contents)
-        except ValueError:
-            warning = f'Need additional plugin to use {self.source._driver} driver'
-            return pretty_describe(contents) + '\n' + warning
+        contents, warning = self.source._display_content()
+        return pretty_describe(contents) + ('\n' + warning if warning else '')
 
     @property
     def label(self):

--- a/intake/gui/tests/test_source_view.py
+++ b/intake/gui/tests/test_source_view.py
@@ -59,11 +59,12 @@ def test_description_with_fake_driver_shows_missing_plugin_warning(sources1):
     from ..source_view import Description
 
     description = Description(source=sources1[1])
-    assert description.contents == ('container: None\n'
+    assert description.contents == ('name: fake1\n'
+                                    'container: None\n'
                                     'description: \n'
                                     'direct_access: forbid\n'
                                     'user_parameters: []\n'
-                                    'Need additional plugin to use fake driver')
+                                    'Need an additional plugin to load fake1.')
     assert_panel_matches_contents(description)
 
 
@@ -73,6 +74,7 @@ def test_description_source_with_plots(sources2):
     assert description.source == sources2[0]
     catalog_dir = sources2[0].metadata['catalog_dir']
     assert description.contents == (
+        'name: us_crime\n'
         'container: dataframe\n'
         'description: US Crime data [UCRDataTool](https://www.ucrdatatool.gov/Search/Crime/State/StatebyState.cfm)\n'
         'direct_access: forbid\n'

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -120,3 +120,11 @@ def remake_instance(data):
     module = importlib.import_module(mod)
     cl = getattr(module, klass)
     return cl(*data.get('args', ()), **data.get('kwargs', {}))
+
+
+def pretty_describe(object, nestedness=0, indent=2):
+    """Maintain dict ordering - but make string version prettier"""
+    if not isinstance(object, dict):
+        return str(object)
+    sep = f'\n{" " * nestedness * indent}'
+    return sep.join((f'{k}: {pretty_describe(v, nestedness + 1)}' for k, v in object.items()))


### PR DESCRIPTION
Fixes #326, fixes #311.

This adds an `_ipython_display_` hook to catalog entries to better display them in a rich context. It sends over two mimetypes:
1. `text/plain` which should be viewable by all frontends, and uses the `pretty_describe` utility function,
2. `application/json`, which should be renderable with more modern frontends (JupyterLab, nteract), and allows for a collapsible and filterable view of the data:

![image](https://user-images.githubusercontent.com/5728311/56684446-9dc28d00-6684-11e9-888c-3f834944b226.png)

We could also consider rendering something nicely with html or markdown, but I thought this was okay for the time being. The collapsible JSON rendering also allows for the flexibility of showing arbitrary metadata.