### PR TITLE
Simplify describe and describe_open

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,11 +1,11 @@
 name: intake
 channels:
   - defaults
-  - intake
   - conda-forge
 
 dependencies:
   - appdirs
+  - cloudpickle
   - python=3.6
   - dask
   - numpy
@@ -19,7 +19,7 @@ dependencies:
   - python-snappy
   - pyyaml
   - holoplot
-  - pip:
-    - sphinx
-    - sphinx-rtd-theme
-    - numpydoc
+  - sphinx
+  - sphinx_rtd_theme
+  - numpydoc
+  - panel >=0.5.0

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -40,31 +40,6 @@ class CatalogEntry(DictSerialiseMixin):
         """
         raise NotImplementedError
 
-    def describe_open(self, **user_parameters):
-        """Get a dictionary describing how to open this data source.
-
-        Parameters
-        ----------
-          user_parameters : dict
-              Values for user-configurable parameters for this data source
-
-        Returns: dict with keys
-          plugin : str
-              Name of data plugin to use
-          container: str
-              Data type returned
-          description : str
-              Markdown-friendly description of data source
-          direct_access : str
-              Mode of remote access: forbid, allow, force
-          metadata : dict
-              Dictionary of metadata defined in the catalog for this data source
-          args: dict
-              Dictionary of keyword arguments for the plugin
-
-        """
-        raise NotImplementedError
-
     def get(self, **user_parameters):
         """Open the data source.
 
@@ -127,25 +102,13 @@ class CatalogEntry(DictSerialiseMixin):
 
     def _ipython_display_(self):
         """Display the entry as a rich object in an IPython session."""
-        contents, warning = self._display_content()
-        display({ # noqa: F821
+        contents = self.describe()
+        display({  # noqa: F821
             'application/json': contents,
             'text/plain': pretty_describe(contents)
         }, metadata={
-            'application/json': { 'root': contents["name"]}
+            'application/json': {'root': contents["name"]}
         }, raw=True)
-        if warning:
-            display(warning) # noqa: F821
-
-    def _display_content(self):
-        """Create a dictionary with content to display in reprs."""
-        contents = deepcopy(self.describe())
-        warning = None
-        try:
-            contents.update(self.describe_open())
-        except ValueError:
-            warning = f'Need an additional plugin to load {contents["name"]}.'
-        return contents, warning
 
     def __getattr__(self, attr):
         if attr in self.__dict__:
@@ -180,7 +143,7 @@ class CatalogEntry(DictSerialiseMixin):
         return self._get_default_source()[item]
 
     def __repr__(self):
-        return "<Catalog Entry: %s>" % self.name
+        return pretty_describe(self.describe())
 
     @property
     def gui(self):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -209,9 +209,12 @@ class LocalCatalogEntry(CatalogEntry):
         return {
             'name': self._name,
             'container': self._container,
+            'driver': str(self._plugin),
             'description': self._description,
             'direct_access': self._direct_access,
-            'user_parameters': [u.describe() for u in self._user_parameters]
+            'user_parameters': [u.describe() for u in self._user_parameters],
+            'metadata': self._metadata,
+            'args': self._open_args
         }
 
     def _create_open_args(self, user_parameters):
@@ -251,16 +254,6 @@ class LocalCatalogEntry(CatalogEntry):
                                  'perhaps import of plugin failed' % plugin)
         return plugin, open_args
 
-    def describe_open(self, **user_parameters):
-        _, args = self._create_open_args(user_parameters)
-        return {
-            'container': self._container,
-            'plugin': self._driver,
-            'description': self._description,
-            'direct_access': self._direct_access,
-            'metadata': self._metadata,
-            'args': args
-        }
 
     def get(self, **user_parameters):
         """Instantiate the DataSource for the given parameters"""

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -21,7 +21,7 @@ from ..source import registry as global_registry
 from ..source import get_plugin_class
 from ..source.discovery import load_plugins_from_module
 from .utils import expand_defaults, coerce, COERCION_RULES, merge_pars
-from ..utils import yaml_load, DictSerialiseMixin, make_path_posix
+from ..utils import yaml_load, DictSerialiseMixin, make_path_posix, classname
 
 logger = logging.getLogger('intake')
 
@@ -206,10 +206,16 @@ class LocalCatalogEntry(CatalogEntry):
 
     def describe(self):
         """Basic information about this entry"""
+        if isinstance(self._plugin, list):
+            pl = [p.name for p in self._plugin]
+        elif isinstance(self._plugin, dict):
+            pl = {k: classname(v) for k, v in self._plugin.items()}
+        else:
+            pl = self._plugin if isinstance(self._plugin, str) else self._plugin.name
         return {
             'name': self._name,
             'container': self._container,
-            'plugin': str(self._plugin),
+            'plugin': pl,
             'description': self._description,
             'direct_access': self._direct_access,
             'user_parameters': [u.describe() for u in self._user_parameters],
@@ -253,7 +259,6 @@ class LocalCatalogEntry(CatalogEntry):
                 raise ValueError('Attempt to select not available plugin %s, '
                                  'perhaps import of plugin failed' % plugin)
         return plugin, open_args
-
 
     def get(self, **user_parameters):
         """Instantiate the DataSource for the given parameters"""

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -209,7 +209,7 @@ class LocalCatalogEntry(CatalogEntry):
         return {
             'name': self._name,
             'container': self._container,
-            'driver': str(self._plugin),
+            'plugin': str(self._plugin),
             'description': self._description,
             'direct_access': self._direct_access,
             'user_parameters': [u.describe() for u in self._user_parameters],

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -55,24 +55,15 @@ class RemoteCatalogEntry(CatalogEntry):
         super(RemoteCatalogEntry, self).__init__(getenv=getenv,
                                                  getshell=getshell)
 
-    @property
-    def kwargs(self):
-        return dict(name=self.name,
-                    container=self.container, description=self.description,
-                    direct_access=self._direct_access,
-                    user_parameters=self._user_parameters
-                    )
-
     def describe(self):
-        return self.kwargs
-
-    def describe_open(self, **kwargs):
         return {
+            'name': self.name,
             'container': self.container,
-            'plugin': None,
+            'plugin': "remote",
             'description': self.description,
             'direct_access': self._direct_access,
             'metadata': self._metadata,
+            'user_paramers': self._user_parameters,
             'args': (self.url, )
         }
 

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -22,7 +22,7 @@ class RemoteCatalogEntry(CatalogEntry):
     def __init__(self, url, auth, name=None, user_parameters=None,
                  container=None, description='', metadata=None,
                  http_args=None, page_size=None, direct_access=False,
-                 getenv=True, getshell=True):
+                 getenv=True, getshell=True, **kwags):
         """
 
         Parameters

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -654,24 +654,3 @@ def test_no_instance():
 
     # this would error on instantiation with driver not found
     assert e0 != e1
-
-
-def test_display_content(catalog1):
-    entry = catalog1['arr']
-    content, warning = entry._display_content()
-    content['args']['metadata'].pop('catalog_dir') # remove os-dependent paths
-    content['args'].pop('path') # remove os-dependent paths
-    assert warning == None
-    assert content == {
-        'name': 'arr',
-        'container': 'ndarray',
-        'description': 'small array',
-        'direct_access': 'forbid',
-        'user_parameters': [],
-        'plugin': 'numpy',
-        'metadata': {},
-        'args': {
-            'metadata': {},
-            'chunks': 5
-        }
-    }

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -42,7 +42,10 @@ def test_local_catalog(catalog1):
         'container': 'dataframe',
         'direct_access': 'forbid',
         'user_parameters': [],
-        'description': 'entry1 full'
+        'description': 'entry1 full',
+        'args': {'urlpath': '{{ CATALOG_DIR }}/entry1_*.csv'},
+        'metadata': {'bar': [1, 2, 3], 'foo': 'bar'},
+        'plugin': ['csv']
     }
     assert catalog1['entry1_part'].describe() == {
         'name': 'entry1_part',
@@ -57,7 +60,10 @@ def test_local_catalog(catalog1):
             }
         ],
         'description': 'entry1 part',
-        'direct_access': 'allow'
+        'direct_access': 'allow',
+        'args': {'urlpath': '{{ CATALOG_DIR }}/entry1_{{ part }}.csv'},
+        'metadata': {'foo': 'baz', 'bar': [2, 4, 6]},
+        'plugin': ['csv']
     }
     assert catalog1['entry1'].get().container == 'dataframe'
     md = catalog1['entry1'].get().metadata
@@ -69,8 +75,9 @@ def test_local_catalog(catalog1):
     # Specify parameters
     assert catalog1['entry1_part'].get(part='2').container == 'dataframe'
 
+
 def test_get_items(catalog1):
-    for key,entry in catalog1.items():
+    for key, entry in catalog1.items():
         assert catalog1[key].describe() == entry.describe()
 
 
@@ -287,7 +294,7 @@ def test_union_catalog():
 
     assert_items_equal(list(union_cat), ['entry1', 'entry1_part', 'use_example1'])
 
-    assert union_cat.entry1_part.describe() == {
+    expected = {
         'name': 'entry1_part',
         'container': 'dataframe',
         'user_parameters': [
@@ -302,19 +309,8 @@ def test_union_catalog():
         'description': 'entry1 part',
         'direct_access': 'allow'
     }
-
-    desc_open = union_cat.entry1_part.describe_open()
-    assert desc_open['args']['urlpath'].endswith('entry1_1.csv')
-    del desc_open['args']['urlpath']  # Full path will be system dependent
-    desc_open['args']['metadata'].pop('catalog_dir')
-    assert 'csv' in str(desc_open.pop('plugin'))
-    assert desc_open == {
-        'args': {'metadata': {'bar': [2, 4, 6], 'foo': 'baz'}},
-        'description': 'entry1 part',
-        'container': 'dataframe',
-        'direct_access': 'allow',
-        'metadata': {'bar': [2, 4, 6], 'foo': 'baz'},
-    }
+    for k in expected:
+        assert union_cat.entry1_part.describe()[k] == expected[k]
 
     # Implied creation of data source
     assert union_cat.entry1.container == 'dataframe'

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -424,19 +424,3 @@ def test_len(intake_server):
     remote_catalog = Catalog(intake_server)
     local_catalog = Catalog(TEST_CATALOG_PATH)
     assert sum(1 for entry in local_catalog) == len(remote_catalog)
-
-def test_display_content(intake_server):
-    remote_catalog = Catalog(intake_server)
-    entry = remote_catalog['arr']
-    content, warning = entry._display_content()
-    assert warning == None
-    assert content == {
-        'name': 'arr',
-        'container': 'ndarray',
-        'description': 'small array',
-        'direct_access': 'forbid',
-        'user_parameters': [],
-        'plugin': None,
-        'metadata': {},
-        'args': ('http://localhost:7483/',)
-    }

--- a/intake/catalog/tests/test_remote_integration.py
+++ b/intake/catalog/tests/test_remote_integration.py
@@ -28,13 +28,15 @@ def test_info_describe(intake_server):
 
     info = catalog['entry1'].describe()
 
-    assert info == {
+    expected = {
         'container': 'dataframe',
         'description': 'entry1 full',
         'name': 'entry1',
         'direct_access': 'forbid',
         'user_parameters': []
     }
+    for k in expected:
+        assert info[k] == expected[k]
 
     info = catalog['entry1_part'].describe()
 

--- a/intake/cli/client/tests/test_local_integration.py
+++ b/intake/cli/client/tests/test_local_integration.py
@@ -34,7 +34,6 @@ def test_full_list():
     out, _ = process.communicate()
     out = out.decode('utf-8')
 
-    assert len(out.strip().split('\n')) == 15
     assert "[entry1]" in out
     assert "[entry1_part]" in out
     assert "[use_example1]" in out
@@ -48,10 +47,13 @@ def test_describe():
     out, _ = process.communicate()
 
     expected = """\
+[entry1] args={'urlpath': '{{ CATALOG_DIR }}/entry1_*.csv'}
 [entry1] container=dataframe
 [entry1] description=entry1 full
 [entry1] direct_access=forbid
+[entry1] metadata={'foo': 'bar', 'bar': [1, 2, 3]}
 [entry1] name=entry1
+[entry1] plugin=['csv']
 [entry1] user_parameters=[]
 """
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -306,7 +306,10 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                                             reason=msg)
             else:
                 # If we get here, the client can access the source directly
+                # some server-side args need to be parsed
                 response = open_desc
+                user_parameters['plugin'] = plugin_name
+                response['args'] = (entry._create_open_args(user_parameters)[1])
                 self.write(msgpack.packb(response, use_bin_type=True))
                 self.finish()
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -272,6 +272,11 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             open_desc = entry.describe()
             direct_access = open_desc['direct_access']
             plugin_name = open_desc['plugin']
+            if isinstance(plugin_name, list):
+                for pl in plugin_name:
+                    if pl in client_plugins:
+                        plugin_name = pl
+                        break
             client_has_plugin = plugin_name in client_plugins
 
             if direct_access == 'forbid' or \
@@ -301,9 +306,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                                             reason=msg)
             else:
                 # If we get here, the client can access the source directly
-                response = dict(
-                    plugin=plugin_name, args=open_desc['args'],
-                    description=open_desc['description'])
+                response = open_desc
                 self.write(msgpack.packb(response, use_bin_type=True))
                 self.finish()
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -269,7 +269,7 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             client_plugins = request.get('available_plugins', [])
 
             # Can the client directly access the data themselves?
-            open_desc = entry.describe_open(**user_parameters)
+            open_desc = entry.describe()
             direct_access = open_desc['direct_access']
             plugin_name = open_desc['plugin']
             client_has_plugin = plugin_name in client_plugins

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -83,7 +83,8 @@ class TestServerV1Info(TestServerV1Base):
 
         for left, right in zip(sort_by_name(info['sources']),
                                sort_by_name(expected)):
-            self.assertDictEqual(left, right)
+            for k in right:
+                assert left[k] == right[k]
 
 
 class TestServerV1Source(TestServerV1Base):
@@ -126,9 +127,11 @@ class TestServerV1Source(TestServerV1Base):
 
         self.assertTrue('csv' in resp_msg['plugin'])
         args = resp_msg['args']
-        self.assertEqual(set(args.keys()), set(['urlpath', 'metadata']))
+        assert set(args) == {'urlpath'}
+        import pdb
+        pdb.set_trace()
         self.assertTrue(args['urlpath'].endswith('/entry1_2.csv'))
-        md = args['metadata']
+        md = resp_msg['metadata']
         md.pop('catalog_dir', None)
         self.assertEqual(md, dict(foo='baz', bar=[2, 4, 6]))
         self.assertEqual(resp_msg['description'], 'entry1 part')

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -127,7 +127,7 @@ class TestServerV1Source(TestServerV1Base):
 
         self.assertTrue('csv' in resp_msg['plugin'])
         args = resp_msg['args']
-        assert set(args) == {'urlpath'}
+        assert 'urlpath' in args
         self.assertTrue(args['urlpath'].endswith('/entry1_2.csv'))
         md = resp_msg['metadata']
         md.pop('catalog_dir', None)

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -128,8 +128,6 @@ class TestServerV1Source(TestServerV1Base):
         self.assertTrue('csv' in resp_msg['plugin'])
         args = resp_msg['args']
         assert set(args) == {'urlpath'}
-        import pdb
-        pdb.set_trace()
         self.assertTrue(args['urlpath'].endswith('/entry1_2.csv'))
         md = resp_msg['metadata']
         md.pop('catalog_dir', None)

--- a/intake/gui/source/description.py
+++ b/intake/gui/source/description.py
@@ -61,12 +61,12 @@ class Description(BaseView):
         """String representation of the source's description"""
         if not self._source:
             return ' ' * 100  # HACK - make sure that area is big
-        contents, warning = self.source._display_content()
+        contents = self.source.describe()
         if 'metadata' in contents and 'plots' in contents['metadata']:
             contents['metadata'].pop('plots')
         if 'args' in contents and 'plots' in contents['args'].get('metadata', {}):
             contents['args']['metadata'].pop('plots')
-        return pretty_describe(contents) + ('\n' + warning if warning else '')
+        return pretty_describe(contents)
 
     @property
     def label(self):

--- a/intake/gui/source/description.py
+++ b/intake/gui/source/description.py
@@ -62,10 +62,6 @@ class Description(BaseView):
         if not self._source:
             return ' ' * 100  # HACK - make sure that area is big
         contents = self.source.describe()
-        if 'metadata' in contents and 'plots' in contents['metadata']:
-            contents['metadata'].pop('plots')
-        if 'args' in contents and 'plots' in contents['args'].get('metadata', {}):
-            contents['args']['metadata'].pop('plots')
         return pretty_describe(contents)
 
     @property

--- a/intake/gui/source/tests/test_source_view.py
+++ b/intake/gui/source/tests/test_source_view.py
@@ -55,19 +55,6 @@ def test_description_clears_if_visible_is_set_to_false(description):
     assert len(description.panel.objects) == 0
 
 
-def test_description_with_fake_driver_shows_missing_plugin_warning(sources1):
-    from ..description import Description
-
-    description = Description(source=sources1[1])
-    assert description.contents == ('name: fake1\n'
-                                    'container: None\n'
-                                    'description: \n'
-                                    'direct_access: forbid\n'
-                                    'user_parameters: []\n'
-                                    'Need an additional plugin to load fake1.')
-    assert_panel_matches_contents(description)
-
-
 def test_description_source_with_plots(sources2):
     from ..description import Description
     description = Description(source=sources2[0])
@@ -79,7 +66,7 @@ def test_description_source_with_plots(sources2):
         'description: US Crime data [UCRDataTool](https://www.ucrdatatool.gov/Search/Crime/State/StatebyState.cfm)\n'
         'direct_access: forbid\n'
         'user_parameters: []\n'
-        'plugin: csv\n'
+        'plugin: [csv]\n'
         'metadata: \n'
         f'args: metadata: catalog_dir: {catalog_dir}\n'
         f'  urlpath: {catalog_dir}../data/crime.csv')

--- a/intake/gui/source/tests/test_source_view.py
+++ b/intake/gui/source/tests/test_source_view.py
@@ -63,13 +63,13 @@ def test_description_source_with_plots(sources2):
     assert description.contents == (
         'name: us_crime\n'
         'container: dataframe\n'
-        'description: US Crime data [UCRDataTool](https://www.ucrdatatool.gov/Search/Crime/State/StatebyState.cfm)\n'
+        "plugin: ['csv']\n"
+        'description: US Crime data [UCRDataTool](https://www.ucrdatatool.gov'
+        '/Search/Crime/State/StatebyState.cfm)\n'
         'direct_access: forbid\n'
         'user_parameters: []\n'
-        'plugin: [csv]\n'
         'metadata: \n'
-        f'args: metadata: catalog_dir: {catalog_dir}\n'
-        f'  urlpath: {catalog_dir}../data/crime.csv')
+        'args: urlpath: {{ CATALOG_DIR }}../data/crime.csv')
     assert_panel_matches_contents(description)
 
 

--- a/intake/gui/source/tests/test_source_view.py
+++ b/intake/gui/source/tests/test_source_view.py
@@ -59,7 +59,7 @@ def test_description_source_with_plots(sources2):
     from ..description import Description
     description = Description(source=sources2[0])
     assert description.source == sources2[0]
-    assert description.contents == (
+    lines = (
         'name: us_crime\n'
         'container: dataframe\n'
         "plugin: ['csv']\n"
@@ -68,7 +68,9 @@ def test_description_source_with_plots(sources2):
         'direct_access: forbid\n'
         'user_parameters: []\n'
         'metadata: \n'
-        'args: urlpath: {{ CATALOG_DIR }}../data/crime.csv')
+        'args:\nurlpath: {{ CATALOG_DIR }}../data/crime.csv').split('\n')
+    for line in lines:
+        assert line in description.contents
     assert_panel_matches_contents(description)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ pandas
 python-snappy
 pyyaml
 requests
-six
 toolz
 tornado >=4.5.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 intake-parquet
 zarr
 notebook
-ipywidgets
 panel==0.5.1
 hvplot==0.4.0


### PR DESCRIPTION
Following #329 , this would be something like "option 3"; this fails on a couple of tests to do with evaluating argument templates on the server when opening directly. I don't have a good answer for what is the right thing to do yet, so posting this for conversation.