### PR TITLE
In GUI code, use describe() rather than attributes

### DIFF
--- a/intake/gui/catalog/select.py
+++ b/intake/gui/catalog/select.py
@@ -94,7 +94,8 @@ class CatSelector(BaseSelector):
         right = '└──'
 
         def get_children(parent):
-            return [e() for e in parent._entries.values() if e._container == 'catalog']
+            return [e() for k, e in parent.items()
+                    if e.describe()['container'] == 'catalog']
 
         if len(cats) == 0:
             return

--- a/intake/gui/source/description.py
+++ b/intake/gui/source/description.py
@@ -67,4 +67,4 @@ class Description(BaseView):
     @property
     def label(self):
         """Label to display at top of panel"""
-        return f'#### Source: {self.source._name}' if self.source else None
+        return f'#### Source: {self.source.describe()["name"]}' if self.source else None

--- a/intake/gui/source/select.py
+++ b/intake/gui/source/select.py
@@ -89,7 +89,8 @@ class SourceSelector(BaseSelector):
         """Set sources from a list of cats"""
         sources = []
         for cat in coerce_to_list(cats):
-            sources.extend([entry for entry in cat._entries.values() if entry._container != 'catalog'])
+            sources.extend([entry for k, entry in cat.items()
+                            if entry.describe()['container'] != 'catalog'])
         self.items = sources
 
     def callback(self, event):


### PR DESCRIPTION
Allows for a difference in attributes between local and remote entries

Fixes #340