### PR TITLE
Fixing up the GUI

### DIFF
--- a/intake/catalog/gui.py
+++ b/intake/catalog/gui.py
@@ -8,7 +8,14 @@ from functools import partial
 
 try:
     import panel as pn
-    from ..gui import SourceGUI, MAX_WIDTH
+    from ..gui.gui import SourceGUI, MAX_WIDTH
+    css = """
+    .scrolling {
+        overflow: scroll;
+    }
+    """
+    pn.config.raw_css.append(css)  # add scrolling class from css (panel GH#383, GH#384)
+    pn.extension()
 
     class EntryGUI(SourceGUI):
         def __init__(self, source=None, **kwargs):
@@ -51,7 +58,6 @@ try:
                 return None
             return self.sources[0]
 
-
 except ImportError:
 
     class GUI(object):
@@ -62,7 +68,6 @@ except ImportError:
 
     EntryGUI = GUI
     CatalogGUI = GUI
-
 
 except Exception as e:
 

--- a/intake/catalog/tests/conftest.py
+++ b/intake/catalog/tests/conftest.py
@@ -1,0 +1,9 @@
+import os.path
+import pytest
+from intake import Catalog
+
+
+@pytest.fixture
+def catalog1():
+    path = os.path.dirname(__file__)
+    return Catalog(os.path.join(path, 'catalog1.yml'))

--- a/intake/catalog/tests/test_gui.py
+++ b/intake/catalog/tests/test_gui.py
@@ -1,0 +1,50 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2012 - 2019, Anaconda, Inc. and Intake contributors
+# All rights reserved.
+#
+# The full license is in the LICENSE file, distributed with this software.
+#-----------------------------------------------------------------------------
+import pytest
+import os
+
+
+def panel_importable():
+    try:
+        import panel as pn
+        return True
+    except:
+        return False
+
+
+@pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
+def test_cat_no_panel_does_not_raise_errors(catalog1):
+    assert catalog1.name == 'catalog1'
+
+
+@pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
+def test_cat_no_panel_display_gui(catalog1):
+    with pytest.raises(RuntimeError, match=('Please install panel to use the GUI '
+                                            '`conda install -c conda-forge panel==0.5.1`')):
+        repr(catalog1.gui)
+
+
+def test_cat_gui(catalog1):
+    pytest.importorskip('panel')
+    assert repr(catalog1.gui).startswith('Row')
+
+
+@pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
+def test_entry_no_panel_does_not_raise_errors(catalog1):
+    assert catalog1.entry1.name == 'entry1'
+
+
+@pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
+def test_entry_no_panel_display_gui(catalog1):
+    with pytest.raises(RuntimeError, match=('Please install panel to use the GUI '
+                                            '`conda install -c conda-forge panel==0.5.1`')):
+        repr(catalog1.entry1.gui)
+
+
+def test_entry_gui(catalog1):
+    pytest.importorskip('panel')
+    assert repr(catalog1.entry1.gui).startswith('Row')

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -27,12 +27,6 @@ def abspath(filename):
         os.path.join(os.path.dirname(__file__), filename))
 
 
-@pytest.fixture
-def catalog1():
-    path = os.path.dirname(__file__)
-    return Catalog(os.path.join(path, 'catalog1.yml'))
-
-
 def test_local_catalog(catalog1):
     assert_items_equal(list(catalog1),
                        ['use_example1', 'nested', 'entry1', 'entry1_part',

--- a/intake/gui/base.py
+++ b/intake/gui/base.py
@@ -68,6 +68,24 @@ class Base(object):
         self.visible_callback = visible_callback
         self.logo = logo
 
+    @property
+    def panel(self):
+        if not self.logo:
+            return self._panel
+        return pn.Row(self.logo_panel,
+                      self._panel,
+                      margin=0)
+
+    @panel.setter
+    def panel(self, panel):
+        self._panel = panel
+
+    def servable(self, *args, **kwargs):
+        return self.panel.servable(*args, **kwargs)
+
+    def show(self, *args, **kwargs):
+        return self.panel.show(*args, **kwargs)
+
     def __repr__(self):
         """Print output"""
         try:
@@ -78,14 +96,7 @@ class Base(object):
     def _repr_mimebundle_(self, *args, **kwargs):
         """Display in a notebook or a server"""
         try:
-            if self.logo:
-                p = pn.Row(
-                    self.logo_panel,
-                    self.panel,
-                    margin=0)
-                return p._repr_mimebundle_(*args, **kwargs)
-            else:
-                return self.panel._repr_mimebundle_(*args, **kwargs)
+            return self.panel._repr_mimebundle_(*args, **kwargs)
         except:
             raise RuntimeError("Panel does not seem to be set up properly")
 
@@ -102,12 +113,12 @@ class Base(object):
     def visible(self, visible):
         """When visible changed, do setup or unwatch and call visible_callback"""
         self._visible = visible
-        if visible and len(self.panel.objects) == 0:
+        if visible and len(self._panel.objects) == 0:
             self.setup()
-            self.panel.extend(self.children)
-        elif not visible and len(self.panel.objects) > 0:
+            self._panel.extend(self.children)
+        elif not visible and len(self._panel.objects) > 0:
             self.unwatch()
-            self.panel.clear()
+            self._panel.clear()
         if self.visible_callback:
             self.visible_callback(visible)
 

--- a/intake/gui/catalog/gui.py
+++ b/intake/gui/catalog/gui.py
@@ -100,19 +100,19 @@ class CatGUI(Base):
         """When visible changed, do setup or unwatch and call visible_callback"""
         self._visible = visible
 
-        if visible and len(self.panel.objects) == 0:
+        if visible and len(self._panel.objects) == 0:
             self.setup()
             self.select.visible = True
             self.control_panel.extend(self.controls)
-            self.panel.extend(self.children)
-        elif not visible and len(self.panel.objects) > 0:
+            self._panel.extend(self.children)
+        elif not visible and len(self._panel.objects) > 0:
             self.unwatch()
             # do children
             self.select.visible = False
             self.control_panel.clear()
             self.search.visible = False
             self.add.visible = False
-            self.panel.clear()
+            self._panel.clear()
         if self.visible_callback:
             self.visible_callback(visible)
 

--- a/intake/gui/server.py
+++ b/intake/gui/server.py
@@ -13,4 +13,4 @@ panel serve intake/gui/server.py
 """
 
 import intake
-intake.gui.panel.servable()
+intake.gui.servable()

--- a/intake/gui/source/gui.py
+++ b/intake/gui/source/gui.py
@@ -91,21 +91,21 @@ class SourceGUI(Base):
         """When visible changed, do setup or unwatch and call visible_callback"""
         self._visible = visible
 
-        if visible and len(self.panel.objects) == 0:
+        if visible and len(self._panel.objects) == 0:
             self.setup()
             self.select.visible = True
             self.description.visible = True
             if len(self.control_panel.objects) == 0:
                 self.control_panel.extend(self.controls)
-            self.panel.extend(self.children)
-        elif not visible and len(self.panel.objects) > 0:
+            self._panel.extend(self.children)
+        elif not visible and len(self._panel.objects) > 0:
             self.unwatch()
             # do children
             self.select.visible = False
             self.control_panel.clear()
             self.description.visible = False
             self.plot.visible = False
-            self.panel.clear()
+            self._panel.clear()
         if self.visible_callback:
             self.visible_callback(visible)
 

--- a/intake/gui/tests/test_init_gui.py
+++ b/intake/gui/tests/test_init_gui.py
@@ -33,4 +33,4 @@ def test_no_panel_display_init_gui():
 def test_display_init_gui():
     pytest.importorskip('panel')
     import intake
-    assert repr(intake.gui).startswith('Column')
+    assert repr(intake.gui).startswith('Row')


### PR DESCRIPTION
Fixes 2 small GUI issues:
 1. When using server version there was no logo
 2. The catalog and entry guis got broken in the import work

Adds:
1. More panel-like methods to the GUI (`show` and `servable`). So now you can do `python -c "import intake; intake.gui.show()"`
2. Tests of cat.gui and entry.gui so they can't get broken again.
