### PR TITLE
Minor typo fix in the "Making Drivers" docs

### DIFF
--- a/docs/source/making-plugins.rst
+++ b/docs/source/making-plugins.rst
@@ -141,7 +141,7 @@ data-frame::
 
         def read(self):
             self._load_metadata()
-            return pd.concat([self.read_partition(i) for i in self.npartitions])
+            return pd.concat([self.read_partition(i) for i in range(self.npartitions)])
 
         def _close(self):
             # close any files, sockets, etc


### PR DESCRIPTION
The sample code in the docs doesn't work. This fixes that.