### PR TITLE
Make test_which more robust.

### DIFF
--- a/intake/catalog/tests/test_default.py
+++ b/intake/catalog/tests/test_default.py
@@ -5,6 +5,7 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from pathlib import Path
 import sys
 from intake.catalog import default
 from intake.catalog.base import Catalog
@@ -12,7 +13,7 @@ from intake.catalog.base import Catalog
 
 def test_which():
     p = default.which('python')
-    assert p == sys.executable
+    assert Path(p).resolve() == Path(sys.executable).resolve()
 
 
 def test_load():


### PR DESCRIPTION
On my system, ``test_which`` get confused by the soft-link between
``python3`` and ``python``.

```python
    def test_which():
        p = default.which('python')
>       assert p == sys.executable
E       AssertionError: assert '/home/dallan...nl/bin/python' == '/home/dallan/...l/bin/python3'
E         - /home/dallan/venv/bnl/bin/python
E         + /home/dallan/venv/bnl/bin/python3
E         ?                                 +

intake/catalog/tests/test_default.py:15: AssertionError
```

This PR uses ``Path.resolve()`` to avoid false-positive failure.