### PR TITLE
initial pass at a to_ibis function.

### DIFF
--- a/intake/container/dataframe.py
+++ b/intake/container/dataframe.py
@@ -51,6 +51,12 @@ class RemoteDataFrame(RemoteSource):
         self._load_metadata()
         return self.dataframe
 
+    def to_ibis(self):
+        import ibis.pandas
+        df = self.read()
+        con = ibis.pandas.connect({'source': df })
+        return con.table('source')
+
     def _close(self):
         self.dataframe = None
 
@@ -177,6 +183,12 @@ class GenericDataFrame(DataSource):
     def to_dask(self):
         self._load_metadata()
         return self.dataframe
+
+    def to_ibis(self):
+        import ibis.pandas
+        df = self.read()
+        con = ibis.pandas.connect({'source': df })
+        return con.table('source')
 
     def _close(self):
         self.dataframe = None

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -203,12 +203,21 @@ class DataSource(DictSerialiseMixin):
         """Return a dask container for this data source"""
         raise NotImplementedError
 
+    def to_ibis(self):
+        """Return an ibis expression for this data source
+
+        Ibis expressions allow construction and lazy evaluation of queries
+        on SQL-like backends. Drivers that target such backends may be able
+        to produce ibis expressions.
+        """
+        raise NotImplementedError
+
     def to_spark(self):
         """Provide an equivalent data object in Apache Spark
 
         The mapping of python-oriented data containers to Spark ones will be
         imperfect, and only a small number of drivers are expected to be able
-        to produce Spark objects. The standard arguments may b translated,
+        to produce Spark objects. The standard arguments may be translated,
         unsupported or ignored, depending on the specific driver.
 
         This method requires the package intake-spark
@@ -447,3 +456,7 @@ class AliasSource(DataSource):
     def to_dask(self):
         self._get_source()
         return self.source.to_dask()
+
+    def to_ibis(self):
+        self._get_source()
+        return self.source.to_ibis()

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -146,6 +146,12 @@ class CSVSource(base.DataSource, base.PatternMixin):
         self._get_schema()
         return self._dataframe
 
+    def to_ibis(self):
+        import ibis.pandas
+        df = self.read()
+        con = ibis.pandas.connect({'source': df })
+        return con.table('source')
+
     def to_spark(self):
         from intake_spark.base import SparkHolder
         h = SparkHolder(True, [

--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -109,6 +109,12 @@ class TextFilesSource(base.DataSource):
         return db.from_delayed([dfile(f, self.decoder, self._read)
                                 for f in self._files])
 
+    def to_ibis(self):
+        import ibis.pandas
+        df = self.read()
+        con = ibis.pandas.connect({'source': df })
+        return con.table('source')
+
 
 def get_file(f, decoder, read):
     """Serializable function to take an OpenFile object and read lines"""


### PR DESCRIPTION
A first pass at implementing #347.  This PR is mostly about establishing an interface for drivers to implement -- it doesn't really do anything useful here.

The idea is that driver authors implement `to_ibis()` which knows how to produce ibis clients for lazy evaluation of expressions on SQL like backends.