### PR TITLE
DOC: Packages with drivers must import intake *first* if they import it.

### DIFF
--- a/docs/source/making-plugins.rst
+++ b/docs/source/making-plugins.rst
@@ -230,6 +230,16 @@ Entry points are a way for Python packages to advertise objects with some
 common interface. When Intake is imported, it discovers all packages installed
 in the current environment that advertise ``'intake.drivers'`` in this way.
 
+Most packages that define intake drivers have a dependency on ``intake``
+itself, for example in order to use intake's base classes. This can create a
+ciruclar dependency: importing the package imports intake, which tries
+to discover and import packages that define drivers. To avoid this pitfall,
+just ensure that ``intake`` is imported first thing in your package's
+``__init__.py``. This ensures that the driver-discovery code runs first. Note
+that you are *not* required to make your package depend on intake. The rule is
+that *if* you import ``intake`` you must import it first thing. If you do not
+import intake, there is no circularity.
+
 Configuration
 '''''''''''''
 


### PR DESCRIPTION
As we update packages that provide intake drivers to use the new entrypoints-based discovery mechansim (tracking issue https://github.com/intake/intake/issues/392) we are also adding

```python
import intake
del intake  # optional -- just if we want to keep the namespace clean
```

to each package's top-level `__init__.py`. This PR adds documentation encouraging future driver authors to do this same. In the PR description here I will explain in more detail why it is needed.

@ian-r-rose [pointed out](https://github.com/bluesky/intake-bluesky/pull/62#discussion_r307789108)  that this extra ceremony seems a bit unfortunate, and I agree. I dug in a little more to clarify whether it is really necessary and to sort out why it didn't seem to be necessary under the old driver discovery mechanism. I learned that, in fact, the old mechanism had this problem too, but driver discovery _failed silently_ if a driver-providing package happened to be imported before `intake` itself was imported. Here is a demonstration of that silent failure using the last releases of intake and intake-xarray _before_ the entrypoints-based mechanism went in.

```
$ python -c "import intake; print(intake.__version__)"
0.5.1
$ python -c "import intake_xarray; print(intake_xarray.__version__)"
0.3.0
$ python -c "import intake; import intake_xarray; print('rasterio' in intake.registry)"
True
$ python -c "import intake_xarray; import intake; print('rasterio' in intake.registry)"
False
```

That is, intake doesn't find the drivers in `intake_xarray` if `intake_xarray` is imported first.

Now update `intake` to the first release with the entrypoints mechanism, but still with pre-entrypoints intake-xarray. The problem persists as it was. (The only difference is the `FutureWarning` from intake, telling us we should update intake-xarray to use entrypoints.)

```
$ python -c "import intake; print(intake.__version__)"
/home/dallan/Repos/bnl/intake/intake/source/discovery.py:136: FutureWarning: The drivers ['xarray_image', 'netcdf', 'opendap', 'rasterio', 'remote-xarray', 'zarr'] do not specify entry_points and were only discovered via a package scan. This may break in a future release of intake. The packages should be updated.
  FutureWarning)
0.5.2
$ python -c "import intake_xarray; print(intake_xarray.__version__)"
0.3.0
$ python -c "import intake; import intake_xarray; print('rasterio' in intake.registry)"
/home/dallan/Repos/bnl/intake/intake/source/discovery.py:136: FutureWarning: The drivers ['xarray_image', 'netcdf', 'opendap', 'rasterio', 'remote-xarray', 'zarr'] do not specify entry_points and were only discovered via a package scan. This may break in a future release of intake. The packages should be updated.
  FutureWarning)
True
$ python -c "import intake_xarray; import intake; print('rasterio' in intake.registry)"
False
```

Now let's update intake-xarray to use entrypoints. With the new mechanism, import order still matters, but now we fail loudly if we import `intake_xarray` first instead of silently missing its drivers. (The packages were never released in this state; here I am using a local branch to demonstrate.)

```
$ python -c "import intake; import intake_xarray; print('rasterio' in intake.registry)"
True
$ python -c "import intake_xarray;"
2019-08-13 15:25:48,899 - intake - ERROR - discovery.py:autodiscover:L147 - Error while loading entrypoint netcdf
Traceback (most recent call last):
  File "/home/dallan/Repos/bnl/intake/intake/source/discovery.py", line 248, in _load_entrypoint
    return entrypoint.load()
  File "/home/dallan/venv/bnl/lib/python3.6/site-packages/entrypoints.py", line 86, in load
    obj = getattr(obj, attr)
AttributeError: module 'intake_xarray.netcdf' has no attribute 'NetCDFSource'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/dallan/Repos/bnl/intake/intake/source/discovery.py", line 143, in autodiscover
    drivers[entrypoint.name] = _load_entrypoint(entrypoint)
  File "/home/dallan/Repos/bnl/intake/intake/source/discovery.py", line 257, in _load_entrypoint
    f"{entrypoint.module_name}.") from err
intake.source.discovery.ConfigurationError: Failed to load netcdf driver because no object named NetCDFSource could be found in the module intake_xarray.netcdf.
```

To get everything working properly regardless of the user's import order, we add `import intake` to `intake_xarray/__init__.py` before importing anything from `intake_xarray` submodules. This is the state of intake-xarray released as 0.3.1.

```
$ python -c "import intake; print(intake.__version__)"
0.5.2
$ python -c "import intake_xarray; print(intake_xarray.__version__)"
0.3.1
$ python -c "import intake; import intake_xarray; print('rasterio' in intake.registry)"
True
$ python -c "import intake_xarray; import intake; print('rasterio' in intake.registry)"
True
```

I believe this is workaround is unavoidable for as long as we need to support the old "package scan" mechanism. But when we eventually drop it and go entrypoints-only, I believe we can defer the importing of the drivers in order to remove the circularity.