### PR TITLE
Use a generator for pagination.

### DIFF
--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -105,7 +105,7 @@ class ServerInfoHandler(tornado.web.RequestHandler):
             else:
                 start = int(page_offset)
                 stop = int(page_offset) + int(page_size)
-            page = itertools.islice(cat.walk(depth=1).items(), start, stop)
+            page = itertools.islice(cat.items(), start, stop)
             for name, source in page:
                 if self.auth.allow_access(head, source, self.catalog):
                     info = source.describe().copy()


### PR DESCRIPTION
The `walk()` method returns a list. The `items()` method, added in
#317, returns a generator.

Tested on a large catalog (70k entries) this change makes a big
difference to overall performance, as one would expect.