### PR TITLE
Improve UserParameter __repr__.

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -79,14 +79,10 @@ class UserParameter(DictSerialiseMixin):
             self.allowed = [coerce(self.type, item)
                             for item in self.allowed]
 
-    def __str__(self):
-        return ('UserParameter(name={self.name!r}, '
-                'description={self.description!r}, '
-                'type={self.type!r}, '
-                'default={self.default!r}, '
-                'min={self.min!r}, '
-                'max={self.max!r}, '
-                'allowed={self.allowed!r})'.format(self=self))
+    def __repr__(self):
+        return (f'<{self.__class__.__name__} {self.name!r}>')
+
+    __str__ = __repr__
 
     def describe(self):
         """Information about this parameter"""

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -156,11 +156,10 @@ def test_user_parameter_default_value(dtype, expected):
     assert p.validate(None) == expected
 
 
-def test_user_parameter_str_method():
+def test_user_parameter_repr():
     p = local.UserParameter('a', 'a desc', 'str')
-    expected = ("UserParameter(name='a', description='a desc', type='str', "
-                "default='', min=None, max=None, allowed=None)")
-    assert str(p) == expected
+    expected = "<UserParameter 'a'>"
+    assert repr(p) == str(p) == expected
 
 
 @pytest.mark.parametrize("dtype,given,expected", [


### PR DESCRIPTION
In #255 we wanted a UserParameter repr that was more useful but not too
verbose. We settled on making `__str__` a complete eval-able
representation but leaving `__repr__` as the not-so-descriptive `object`
defaut.

I propose a different compromise: unify `__str__` and `__repr__` but use
a succinct non-eval-able repr, `<UserParameter 'some_name_here'>` where,
as in the standard library `<>` is used to indicate the the repr is not
eval-able but merely a summary.

Reasoning:

* An eval-able representation is nice, but our current implementation of
eval-able `__str__` is backward: normally it's the `__repr__` that is
(where possible) eval-able. If we agree that the eval-able string is too
verbose, maybe it would be better to settle on short but still useful
repr.
* Python _supports_ different `__str__` and `__repr__` but to my taste
it's nice when they can be consistent. When presented with a
not-so-useful `__repr__`, it doesn't always occur to me to try printing
it to see if the `__str__` representation is better.

Closes #465