### PR TITLE
Do driver registration through a function.

### DIFF
--- a/docs/source/api_user.rst
+++ b/docs/source/api_user.rst
@@ -6,6 +6,8 @@ These are reference class and function definitions likely to be useful to everyo
 .. autosummary::
    intake.open_catalog
    intake.registry
+   intake.register_driver
+   intake.unregister_driver
    intake.upload
    intake.open_
    intake.source.csv.CSVSource

--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -70,38 +70,15 @@ Extra drivers
 The ``driver:`` entry of a data source specification can be a driver name, as has been shown in the examples so far.
 It can also be an absolute class path to use for the data source, in which case there will be no ambiguity about how
 to load the data. That is the the preferred way to be explicit, when the driver name alone is not enough
-(see `Driver Selection`_, below). However,
-it is also possible to specify extra modules and directories to scan for plugins, as an alternative method for
-finding driver classes.
-
-In addition to using drivers already installed in the Python environment with conda or pip
-(see :ref:`driver-discovery`), a catalog can also use additional drivers from arbitrary locations listed in the YAML
-file:
+(see `Driver Selection`_, below).
 
 .. code-block:: yaml
 
     plugins:
       source:
         - module: intake.catalog.tests.example1_source
-        - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
     sources:
       ...
-
-
-The following import methods are allow:
-
-- ``- module: my.module.path``: The Python module to import and search for driver classes.  This uses the standard
-  notation of the Python ``import`` command and will search the PYTHONPATH in the same way.
-- ``- dir: /my/module/directory``: All of the ``*.py`` files in this directory will be executed, and any driver
-  classes found will be added to the catalog's plugin registry.  It is common for the directory of Python files to be
-  stored relative to the catalog file itself, so using the ``CATALOG_DIR`` variable will allow that relative path to be
-  specified.
-
-Each of the above methods can be used multiple times, and in combination, to load as many extra drivers as are needed.
-Most drivers should be installed as Python packages (enabling autodiscovery), but sometimes catalog-specific drivers may
-be needed to perform specific data transformations that are not broadly applicable enough to warrant creating a
-dedicated package.  In those cases, the above options allow the drivers to be bundled with the catalog instead.
-
 
 Sources
 '''''''

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -19,20 +19,16 @@ from .catalog import local
 from .catalog.default import load_combo_catalog
 from .catalog.local import MergedCatalog, EntrypointsCatalog
 from .container import upload
-from .source import registry
+from .source import register_driver, registry
 from .source.discovery import autodiscover
 from .gui import InstanceMaker
 
 # Populate list of autodetected drivers (plugins).
-registry.update(autodiscover())
+# The built-in ones are included here because intake itself declares them via
+# its own entry_points.
+for name, driver in autodiscover().items():
+    register_driver(name, driver)
 
-from .source import csv, textfiles, npy, zarr
-registry['csv'] = csv.CSVSource
-registry['textfiles'] = textfiles.TextFilesSource
-registry['catalog'] = Catalog
-registry['intake_remote'] = RemoteCatalog
-registry['numpy'] = npy.NPySource
-registry['ndzarr'] = zarr.ZarrArraySource
 logger = logging.getLogger('intake')
 
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -19,7 +19,7 @@ from .. import __version__
 from .base import Catalog, DataSource
 from . import exceptions
 from .entry import CatalogEntry
-from ..source import registry as global_registry
+from ..source import register_driver
 from ..source import get_plugin_class
 from ..source.discovery import load_plugins_from_module
 from .utils import (expand_defaults, coerce, COERCION_RULES, merge_pars,
@@ -512,7 +512,7 @@ def register_plugin_module(mod):
         if k:
             if isinstance(k, (list, tuple)):
                 k = k[0]
-            global_registry[k] = v
+            register_driver(k, v)
 
 
 def register_plugin_dir(path):
@@ -521,7 +521,7 @@ def register_plugin_dir(path):
     for f in glob.glob(path + '/*.py'):
         for k, v in load_plugins_from_module(f).items():
             if k:
-                global_registry[k] = v
+                register_driver(k, v)
 
 
 def get_dir(path):
@@ -844,5 +844,8 @@ class EntrypointsCatalog(Catalog):
                 warings.warn(f"Failed to load {name}, {entrypoint}, {e!r}.")
 
 
-global_registry['yaml_file_cat'] = YAMLFileCatalog
-global_registry['yaml_files_cat'] = YAMLFilesCatalog
+# Register these early in the import process to support the default catalog
+# which is built at import time. (Without this, 'yaml_file_cat' is looked for
+# in intake.registry before the registry has been populated.)
+register_driver('yaml_file_cat', YAMLFileCatalog)
+register_driver('yaml_files_cat', YAMLFilesCatalog)

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -512,7 +512,11 @@ def register_plugin_module(mod):
         if k:
             if isinstance(k, (list, tuple)):
                 k = k[0]
-            register_driver(k, v)
+            # load_plugins_from_module can employ imp.load_source in which case
+            # we will re-exec the code and get a different type each time, so
+            # we have to tolerate overwriting here.
+            uses_load_source = mod.endswith('.py')
+            register_driver(k, v, overwrite=uses_load_source)
 
 
 def register_plugin_dir(path):
@@ -521,7 +525,10 @@ def register_plugin_dir(path):
     for f in glob.glob(path + '/*.py'):
         for k, v in load_plugins_from_module(f).items():
             if k:
-                register_driver(k, v)
+                # load_plugins_from_module can employ imp.load_source in which
+                # case we will re-exec the code and get a different type each
+                # time, so we have to tolerate overwriting here.
+                register_driver(k, v, overwrite=True)
 
 
 def get_dir(path):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -350,18 +350,16 @@ class CatalogParser(object):
                            "dictionary", data['plugins'], 'source')
                 continue
 
-            if 'module' in plugin_source and 'dir' in plugin_source:
-                self.error("keys 'module' and 'dir' both exist (select only "
-                           "one)", plugin_source)
-            elif 'module' in plugin_source:
+            if 'module' in plugin_source:
                 register_plugin_module(plugin_source['module'])
             elif 'dir' in plugin_source:
-                path = Template(plugin_source['dir']).render(
-                    {'CATALOG_DIR': self._context['root']})
-                register_plugin_dir(path)
+                self.error(
+                    "The key 'dir', and in general the feature of registering "
+                    "plugins from a directory of Python scripts outside of "
+                    "sys.path, is no longer supported. Use 'module'.",
+                    plugin_source)
             else:
-                self.error("missing one of the available keys ('module' or "
-                           "'dir')", plugin_source)
+                self.error("missing 'module'", plugin_source)
 
     def _getitem(self, obj, key, dtype, required=True, default=None,
                  choices=None):
@@ -512,23 +510,7 @@ def register_plugin_module(mod):
         if k:
             if isinstance(k, (list, tuple)):
                 k = k[0]
-            # load_plugins_from_module can employ imp.load_source in which case
-            # we will re-exec the code and get a different type each time, so
-            # we have to tolerate overwriting here.
-            uses_load_source = mod.endswith('.py')
-            register_driver(k, v, overwrite=uses_load_source)
-
-
-def register_plugin_dir(path):
-    """Find plugins in given directory"""
-    import glob
-    for f in glob.glob(path + '/*.py'):
-        for k, v in load_plugins_from_module(f).items():
-            if k:
-                # load_plugins_from_module can employ imp.load_source in which
-                # case we will re-exec the code and get a different type each
-                # time, so we have to tolerate overwriting here.
-                register_driver(k, v, overwrite=True)
+            register_driver(k, v)
 
 
 def get_dir(path):

--- a/intake/catalog/tests/catalog1.yml
+++ b/intake/catalog/tests/catalog1.yml
@@ -4,7 +4,7 @@ metadata:
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin

--- a/intake/catalog/tests/catalog_caching.yml
+++ b/intake/catalog/tests/catalog_caching.yml
@@ -3,7 +3,7 @@ metadata:
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example2_source
 sources:
   test_cache:
     description: cache a csv file from the local filesystem

--- a/intake/catalog/tests/catalog_union_2.yml
+++ b/intake/catalog/tests/catalog_union_2.yml
@@ -1,7 +1,7 @@
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example2_source
 sources:
   entry1:
     description: entry1 full

--- a/intake/catalog/tests/plugins_source_both.yml
+++ b/intake/catalog/tests/plugins_source_both.yml
@@ -1,5 +1,0 @@
-plugins:
-  source:
-    - module: a.b.c
-      dir: abc
-sources: {}

--- a/intake/catalog/tests/test_gui.py
+++ b/intake/catalog/tests/test_gui.py
@@ -20,7 +20,7 @@ EXPECTED_ERROR_TEXT = "Please install panel to use the GUI"
 
 @pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
 def test_cat_no_panel_does_not_raise_errors(catalog1):
-    assert catalog1.name == 'catalog1'
+    assert catalog1.name == 'name_in_cat'
 
 
 @pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")

--- a/intake/catalog/tests/test_gui.py
+++ b/intake/catalog/tests/test_gui.py
@@ -15,6 +15,8 @@ def panel_importable():
     except:
         return False
 
+EXPECTED_ERROR_TEXT = "Please install panel to use the GUI"
+
 
 @pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
 def test_cat_no_panel_does_not_raise_errors(catalog1):
@@ -23,8 +25,7 @@ def test_cat_no_panel_does_not_raise_errors(catalog1):
 
 @pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
 def test_cat_no_panel_display_gui(catalog1):
-    with pytest.raises(RuntimeError, match=('Please install panel to use the GUI '
-                                            '`conda install -c conda-forge panel==0.5.1`')):
+    with pytest.raises(RuntimeError, match=EXPECTED_ERROR_TEXT):
         repr(catalog1.gui)
 
 
@@ -40,8 +41,7 @@ def test_entry_no_panel_does_not_raise_errors(catalog1):
 
 @pytest.mark.skipif(panel_importable(), reason="panel is importable, so skip")
 def test_entry_no_panel_display_gui(catalog1):
-    with pytest.raises(RuntimeError, match=('Please install panel to use the GUI '
-                                            '`conda install -c conda-forge panel==0.5.1`')):
+    with pytest.raises(RuntimeError, match=EXPECTED_ERROR_TEXT):
         repr(catalog1.entry1.gui)
 
 

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -259,7 +259,6 @@ def test_user_parameter_validation_allowed():
     "params_value_bad_type",
     "params_value_non_dict",
     "plugins_non_dict",
-    "plugins_source_both",
     "plugins_source_missing",
     "plugins_source_missing_key",
     "plugins_source_non_dict",

--- a/intake/catalog/tests/test_reload_integration.py
+++ b/intake/catalog/tests/test_reload_integration.py
@@ -39,7 +39,7 @@ def intake_server_with_config(intake_server):
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin
@@ -64,7 +64,7 @@ def test_reload_updated_config(intake_server_with_config):
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin
@@ -119,7 +119,7 @@ def test_reload_missing_remote_directory(intake_server):
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin
@@ -144,7 +144,7 @@ def test_reload_missing_local_directory(tempdir):
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin

--- a/intake/cli/client/tests/catalog1.yml
+++ b/intake/cli/client/tests/catalog1.yml
@@ -1,7 +1,7 @@
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin

--- a/intake/cli/server/tests/catalog1.yml
+++ b/intake/cli/server/tests/catalog1.yml
@@ -1,7 +1,7 @@
 plugins:
   source:
     - module: intake.catalog.tests.example1_source
-    - dir: '{{ CATALOG_DIR }}/example_plugin_dir'
+    - module: intake.catalog.tests.example_plugin_dir.example2_source
 sources:
   use_example1:
     description: example1 source plugin

--- a/intake/container/__init__.py
+++ b/intake/container/__init__.py
@@ -9,17 +9,69 @@ from .dataframe import RemoteDataFrame
 from .ndarray import RemoteArray
 from .semistructured import RemoteSequenceSource
 from ..catalog.base import RemoteCatalog
+from ..utils import ContainerRegistryView
 
 # each container type is represented in the remote by one of the classes in
 # this dictionary
-container_map = {
+_container_map = {
     'dataframe': RemoteDataFrame,
     'python': RemoteSequenceSource,
     'ndarray': RemoteArray,
     'catalog': RemoteCatalog
 }
+container_map = ContainerRegistryView(_container_map)  # public, read-only view
 
-__all__ = ['container_map']
+__all__ = ['container_map', 'register_container', 'unregister_container']
+
+
+def register_container(name, container, overwrite=False):
+    """
+    Add to the container registry, ``intake.container.container_map``.
+
+    Parameters
+    ----------
+    name: string
+    container: DataSource
+    overwrite: bool, optional
+        False by default.
+
+    Raises
+    ------
+    ValueError
+        If name collides with an existing name in the container registry and
+        overwrite is False.
+    """
+    if name in _container_map and not overwrite:
+        # If we are re-registering the same object, there is no problem.
+        original = _container_map[name]
+        if original is container:
+            return
+        raise ValueError(
+            f"The container {container} could not be registered for the "
+            f"name {name} because {_container_map[name]} is already "
+            f"registered for that name. Use overwrite=True to force it.")
+    _container_map[name] = container
+
+
+def unregister_container(name):
+    """
+    Ensure that a given name in the container registry is cleared.
+
+    This function is idempotent: if the name does not exist in
+    ``intake.container.container_map``, nothing is done, and the function
+    returns None
+
+    Parameters
+    ----------
+    name: string
+
+    Returns
+    -------
+    container: DataSource or None
+        Whatever was registered for ``name``, or ``None``
+    """
+    return _container_map.pop(name, None)
+
 
 
 def upload(data, path, **kwargs):

--- a/intake/source/__init__.py
+++ b/intake/source/__init__.py
@@ -8,11 +8,11 @@
 import logging
 logger = logging.getLogger('intake')
 
-from ..utils import RegistryView
+from ..utils import DriverRegistryView
 
 # The registry is the mapping of plugin name (aka driver) to DataSource class
 _registry = {}  # internal mutable registry
-registry = RegistryView(_registry)  # public, read-ony wrapper
+registry = DriverRegistryView(_registry)  # public, read-ony wrapper
 
 
 def register_driver(name, driver, overwrite=False):

--- a/intake/source/__init__.py
+++ b/intake/source/__init__.py
@@ -8,8 +8,60 @@
 import logging
 logger = logging.getLogger('intake')
 
+from ..utils import RegistryView
+
 # The registry is the mapping of plugin name (aka driver) to DataSource class
-registry = {}
+_registry = {}  # internal mutable registry
+registry = RegistryView(_registry)  # public, read-ony wrapper
+
+
+def register_driver(name, driver, overwrite=False):
+    """
+    Add a driver to intake.registry.
+
+    Parameters
+    ----------
+    name: string
+    driver: DataSource
+    overwrite: bool, optional
+        False by default.
+
+    Raises
+    ------
+    ValueError
+        If name collides with an existing name in the registry and overwrite is
+        False.
+    """
+    if name in _registry and not overwrite:
+        # If we are re-registering the same object, there is no problem.
+        original = _registry[name]
+        if original is driver:
+            return
+        raise ValueError(
+            f"The driver {driver} could not be registered for the "
+            f"name {name} because {_registry[name]} is already "
+            f"registered for that name. Use overwrite=True to force it.")
+    _registry[name] = driver
+
+
+def unregister_driver(name):
+    """
+    Ensure that a given name in the registry is cleared.
+
+    This function is idempotent: if the name does not exist, nothing is done,
+    and the function returns None
+
+    Parameters
+    ----------
+    name: string
+
+    Returns
+    -------
+    driver: DataSource or None
+        Whatever was registered for ``name``, or ``None``
+    """
+    return _registry.pop(name, None)
+
 
 # A set of fully-qualifies package.module.Class mappings
 classes = {}

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -298,11 +298,20 @@ def load_plugins_from_module(module_name):
     plugins = {}
 
     try:
-        if module_name.endswith('.py'):
-            import imp
-            mod = imp.load_source('module.name', module_name)
-        else:
+        try:
             mod = importlib.import_module(module_name)
+        except ImportError as error:
+            if module_name.endswith('.py'):
+                # Provide a specific error regarding the removal of behavior
+                # that intake formerly supported.
+                raise ImportError(
+                    "Intake formerly supported executing arbitrary Python "
+                    "files not on the sys.path. This is no longer supported. "
+                    "Drivers must be specific with a module path like "
+                    "'package_name.module_name, not a Python filename like "
+                    "'module.py'.") from error
+            else:
+                raise
     except Exception as e:
         logger.debug("Import module <{}> failed: {}".format(module_name, e))
         return {}

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -177,6 +177,11 @@ def encode_datetime(obj):
 class RegistryView(collections.abc.Mapping):
     """
     Wrap registry dict in a read-only dict view.
+
+    Subclasses define attributes filled into warning and error messages:
+    - self._registry_name
+    - self._register_func_name
+    - self._unregister_func_name
     """
     def __init__(self, registry):
         self._registry = registry
@@ -197,30 +202,47 @@ class RegistryView(collections.abc.Mapping):
 
     def update(self, *args, **kwargs):
         warnings.warn(
-            "In a future release of intake, the intake.registry will not be "
-            "directly mutable. Use intake.register_driver.",
+            f"In a future release of intake, the {self._registry_name} will "
+            f"not be directly mutable. Use {self._register_func_name}.",
             DeprecationWarning)
         self._registry.update(*args, **kwargs)
         # raise TypeError(
-        #     "The registry cannot be edited directly. "
-        #     "Instead, use the intake.register(key, value)")
+        #     f"The registry cannot be edited directly. "
+        #     f"Instead, use the {self._register_func_name{")
 
     def __setitem__(self, key, value):
         warnings.warn(
-            "In a future release of intake, the intake.registry will not be "
-            "directly mutable. Use intake.register_driver.",
+            f"In a future release of intake, the {self._registry_name} will "
+            f"not be directly mutable. Use {self._register_func_name}.",
             DeprecationWarning)
         self._registry[key] = value
         # raise TypeError(
-        #     "The registry cannot be edited directly. "
-        #     "Instead, use the intake.register(key, value)")
+        #     f"The registry cannot be edited directly. "
+        #     f"Instead, use the {self._register_func_name{")
 
     def __delitem__(self, key):
         warnings.warn(
-            "In a future release of intake, the intake.registry will not be "
-            "directly editable. Use intake.unregister_driver.",
+            f"In a future release of intake, the {self._registry_name} will "
+            f"not be directly mutable. Use {self._unregister_func_name}.",
             DeprecationWarning)
         del self._registry[key]
+        self._registry[key] = value
         # raise TypeError(
-        #     "The registry cannot be edited directly. "
-        #     "Instead, use the method intake.unregister(key).")
+        #     f"The registry cannot be edited directly. "
+        #     f"Instead, use the {self._unregister_func_name{")
+
+
+class DriverRegistryView(RegistryView):
+    # This attributes are used by the base class
+    # to fill in warning and error messages.
+    _registry_name = "intake.registry"
+    _register_func_name  = "intake.register_driver"
+    _unregister_func_name  = "intake.unregister_driver"
+
+
+class ContainerRegistryView(RegistryView):
+    # This attributes are used by the base class
+    # to fill in warning and error messages.
+    _registry_name = "intake.container_map"
+    _register_func_name  = "intake.register_container"
+    _unregister_func_name  = "intake.unregister_container"

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -6,8 +6,10 @@
 #-----------------------------------------------------------------------------
 
 import collections
+import collections.abc
 import datetime
 from contextlib import contextmanager
+import warnings
 import yaml
 
 
@@ -170,3 +172,55 @@ def encode_datetime(obj):
     if isinstance(obj, datetime.datetime):
         return {"__datetime__": True, "as_str": obj.strftime("%Y%m%dT%H:%M:%S.%f%z")}
     return obj
+
+
+class RegistryView(collections.abc.Mapping):
+    """
+    Wrap registry dict in a read-only dict view.
+    """
+    def __init__(self, registry):
+        self._registry = registry
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._registry!r})"
+
+    def __getitem__(self, key):
+        return self._registry[key]
+
+    def __iter__(self):
+        yield from self._registry
+
+    def __len__(self):
+        return len(self._registry)
+
+    # Support the common mutation methods for now, but warn.
+
+    def update(self, *args, **kwargs):
+        warnings.warn(
+            "In a future release of intake, the intake.registry will not be "
+            "directly mutable. Use intake.register_driver.",
+            DeprecationWarning)
+        self._registry.update(*args, **kwargs)
+        # raise TypeError(
+        #     "The registry cannot be edited directly. "
+        #     "Instead, use the intake.register(key, value)")
+
+    def __setitem__(self, key, value):
+        warnings.warn(
+            "In a future release of intake, the intake.registry will not be "
+            "directly mutable. Use intake.register_driver.",
+            DeprecationWarning)
+        self._registry[key] = value
+        # raise TypeError(
+        #     "The registry cannot be edited directly. "
+        #     "Instead, use the intake.register(key, value)")
+
+    def __delitem__(self, key):
+        warnings.warn(
+            "In a future release of intake, the intake.registry will not be "
+            "directly editable. Use intake.unregister_driver.",
+            DeprecationWarning)
+        del self._registry[key]
+        # raise TypeError(
+        #     "The registry cannot be edited directly. "
+        #     "Instead, use the method intake.unregister(key).")


### PR DESCRIPTION
Suggested by @HarinarayanKrishnan

Goals:
* Make the answer to "How do I register a driver at run time?" easier to discover.
* Ensure that two different code bases do not silently step on each other. This can cause trouble:
  ```py
  intake.registry['thing'] = A
  # ... later, perhaps in a different package...
  intake.registry['thing'] = B  # silently changed the registry under us!


This PR attempts to address both of these by introducing a new function `intake.register_driver` and laying a path toward making `intake.registry` an immutable view in the future. It works like this, a nice pattern that I have employed a couple times before to make shared registries safer and avoid confusing bugs.

```py
register_driver('thing', A)
register_driver('thing', A)  # OK, this is redundant but harmless
register_driver('thing', B)  # raises ValueError
register_driver('thing', B, overwrite= True)  # OK, since you have acknowledged that you are stepping on something
```

The code has been updated to use `register_driver` internally, never modifying `intake.registry` directly. Track is laid to make `intake.registry` an immutable view in the future; however, other libraries are likely modifying it directly now, so to start mutation is _support_ but issues a `DeprecationWarning`.

Unfortunately, as noted in code comments, we have to use `overwrite=True` internally in some situations. See #477. But this is should help avoid libraries accidentally stepping on each other and many cases.