### PR TITLE
Replace "is" with literal with "=="

### DIFF
--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -79,7 +79,7 @@ class CatalogEntry(DictSerialiseMixin):
         if s.has_been_persisted and persist is not 'never':
             s2 = s.get_persisted()
             met = s2.metadata
-            if persist is 'always' or not met['ttl']:
+            if persist == 'always' or not met['ttl']:
                 return s2
             if met['ttl'] < time.time() - met['timestamp']:
                 return s2


### PR DESCRIPTION
This fixes a comparison with a literal. I haven't seen any issues from this, but I suspect this is not what was intended.