### PR TITLE
POC: open by mimetype

### DIFF
--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -11,6 +11,7 @@ from .utils import expand_defaults, coerce
 from ..compat import unpack_kwargs, pack_kwargs
 from ..utils import remake_instance
 
+
 class RemoteCatalogEntry(CatalogEntry):
     """An entry referring to a remote data definition"""
     def __init__(self, url, auth, name=None, user_parameters=None,

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -10,6 +10,7 @@ import warnings
 import importlib
 import inspect
 import itertools
+import mimetypes
 import time
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,10 @@ setup(
             'intake_remote = intake.catalog.base:RemoteCatalog',
             'numpy = intake.source.npy:NPySource',
             'ndzarr = intake.source.zarr:ZarrArraySource'
+        ],
+        'intake.mime': [
+            "text/csv = intake.source.csv:CSVSource",
+            "text/plain = intake.source.textfiles:TextFilesSource",
         ]
     },
     classifiers=[


### PR DESCRIPTION
Adds a function to open a URL by guessing the mimetype (or by providing the mimetype).

Deficiencies:
- many of the file types we care about don't have a mimetype, so we probably need our own extension guessing framework too
- ditto for compression
- assumes that the URL is the first and only required parameter to the driver class