### PR TITLE
Suppress or fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       install:
         - sudo apt update
         - sudo apt install libsnappy-dev
-        - pip install panel bokeh dask pytest
+        - pip install panel bokeh dask pytest zarr
         - pip install -e .[complete]
       script:
         - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     # ANACONDA_TOKEN
     secure: XJ+hvBFtSNUy6xYQmpEFVoR1MTYdTtLIN9R46qfW5XhAOEzuA0mDBd4FL9mgaw4+hoB4+3B8ItHquGxRN/ugw8O/VRA5CuGBbmfbJfG2vLKAbe3RruTueijbxIpiPAhgEp11HtLWGYiaXR47Hug/hO5nFnHAqF9DpQfvsO5ntlFcMnNRVFp7uHbkdz651yQ3en4frSLP/07sK7zGMculb5VKeFH7RdD7Imyqi/BqXX3Mq4ymcgJ/lSEbgO46hP1wX6q4/SSFEQyb4tUUgM6yK6nZEjs6R6DLXpW9PFncTHsjBu39+aZR5tFQqRFOMoaVY2WVxDFSC4Hx8kUXuDQMfuR4JgVOEDSDLr8iws7Fr7svWEpz0TfasbN2/j4LSL+4bjtpZE/Baz3TrUf1LsmbjIgGIDiruLcVpQLrD3msHjjHiyldUs3gDCjndPuaxg0f3AKz/04xNXTNxg+RyVIGjP/6dHDRNIyHfToBhkt42wjt4bDiyxK78ty5Qn+EnDPJn1R22dULFXTwMnEO9QbzJCKZz2xwClp8toxHYRTUsjD68IDxipqd4gn6R16OgMcA9wtzomoz5UmFbo3ambUluzMVv3v9KS4spqykPWF8wTuGfJy2pEJAm6E9bwa4Jw1RZx9GWSYp/Zm8QR0Vx10dTTy/X7/wX44f/P9pv/dQUiw=
 
-matrix:
+jobs:
   include:
     # ANACONDA
     - language: generic
@@ -26,10 +26,18 @@ matrix:
         - coveralls
     # PYTHON
     - language: python
-      sudo: required
       dist: bionic
-      python:
-        - "3.7"
+      python: "3.7"
+      install:
+        - sudo apt update
+        - sudo apt install libsnappy-dev
+        - pip install panel bokeh dask pytest
+        - pip install -e .[complete]
+      script:
+        - pytest
+    - language: python
+      dist: bionic
+      python: "3.8"
       install:
         - sudo apt update
         - sudo apt install libsnappy-dev

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -27,8 +27,10 @@ from .gui import InstanceMaker
 # Populate list of autodetected drivers (plugins).
 # The built-in ones are included here because intake itself declares them via
 # its own entry_points.
-for name, driver in autodiscover().items():
-    register_driver(name, driver)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    for name, driver in autodiscover().items():
+        register_driver(name, driver)
 
 logger = logging.getLogger('intake')
 if sys.version_info >= (3, 7):

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -27,10 +27,8 @@ from .gui import InstanceMaker
 # Populate list of autodetected drivers (plugins).
 # The built-in ones are included here because intake itself declares them via
 # its own entry_points.
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    for name, driver in autodiscover().items():
-        register_driver(name, driver)
+for name, driver in autodiscover().items():
+    register_driver(name, driver)
 
 logger = logging.getLogger('intake')
 if sys.version_info >= (3, 7):

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -76,7 +76,7 @@ class CatalogEntry(DictSerialiseMixin):
             raise ValueError('Persist value (%s) not understood' % persist)
         persist = persist or self._pmode
         s = self.get(**kwargs)
-        if s.has_been_persisted and persist is not 'never':
+        if s.has_been_persisted and persist != 'never':
             s2 = s.get_persisted()
             met = s2.metadata
             if persist == 'always' or not met['ttl']:

--- a/intake/catalog/tests/test_zarr.py
+++ b/intake/catalog/tests/test_zarr.py
@@ -7,10 +7,11 @@ from intake.catalog.local import LocalCatalogEntry
 from intake import open_catalog
 from .util import assert_items_equal
 
+zarr = pytest.importorskip('zarr')
+
 
 @pytest.fixture
 def temp_zarr():
-    import zarr
     zarr_path = tempfile.mkdtemp()
 
     # setup a zarr hierarchy stored on local file system
@@ -61,7 +62,6 @@ sources:
 
 @pytest.mark.parametrize('consolidated', [False, True])
 def test_zarr_catalog(temp_zarr, consolidated):
-    import zarr
     import dask.array as da
 
     path, store, root, _ = temp_zarr
@@ -120,7 +120,6 @@ def test_zarr_catalog(temp_zarr, consolidated):
 
 
 def test_zarr_entries_in_yaml_catalog(temp_zarr):
-    import zarr
     import dask.array as da
 
     # open YAML catalog file

--- a/intake/source/cache.py
+++ b/intake/source/cache.py
@@ -116,7 +116,7 @@ class BaseCache(object):
 
         dirname = os.path.dirname(cache_path)
         if not os.path.exists(dirname):
-            if not (dirname.startswith('https://') or 
+            if not (dirname.startswith('https://') or
                     dirname.startswith('http://')):
                 os.makedirs(dirname)
 
@@ -442,7 +442,7 @@ class CompressedCache(BaseCache):
 
 
 class DATCache(BaseCache):
-    """Use the DAT protocol to replicate data
+    r"""Use the DAT protocol to replicate data
 
     For details of the protocol, see https://docs.datproject.org/
     The executable ``dat`` must be available.
@@ -488,7 +488,7 @@ class CacheMetadata(collections.abc.MutableMapping):
     def __init__(self, *args, **kwargs):
         from intake import config
 
-        self._path = posixpath.join(make_path_posix(config.confdir), 
+        self._path = posixpath.join(make_path_posix(config.confdir),
                                     'cache_metadata.json')
         d = os.path.dirname(self._path)
         if not os.path.exists(d):

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -53,10 +53,11 @@ def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
     """
     # Discover drivers via package scan.
     if do_package_scan:
-        warnings.warn(
-            "The option `do_package_scan` may be removed in a future release.",
-            PendingDeprecationWarning)
         package_scan_results = _package_scan(path, plugin_prefix)
+        if package_scan_results:
+            warnings.warn(
+                "The option `do_package_scan` may be removed in a future release.",
+                PendingDeprecationWarning)
     else:
         package_scan_results = {}
 

--- a/intake/source/discovery.py
+++ b/intake/source/discovery.py
@@ -22,7 +22,7 @@ logger = logging.getLogger('intake')
 
 
 def autodiscover(path=None, plugin_prefix='intake_', do_package_scan=True):
-    """Discover intake drivers.
+    r"""Discover intake drivers.
 
     In order of decreasing precedence:
 


### PR DESCRIPTION
This addresses several things that warn on newer versions of python (invalid escape and `!=` vs `is`), suppresses a warning on import, ~and configures pytest to make sure the warnings don't come back~.