### PR TITLE
Perf defer tokenize

### DIFF
--- a/docs/source/persisting.rst
+++ b/docs/source/persisting.rst
@@ -95,7 +95,7 @@ For details on the methods of the persist store, see the API documentation:
 information about the sources they were made from, so that they can be remade
 successfully. This all appears in the source metadata.
 The sources use the "token" of the original
-data source as their key in the store, a value which can be found by ``source._tok``
+data source as their key in the store, a value which can be found by ``dask.base.tokenize(source)``
 for the original source, or can be taken from the metadata of a persisted source.
 
 Note that all of the information about persisted sources is held in a single YAML file in

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -129,10 +129,8 @@ class Catalog(DataSource):
         -------
         Catalog instance
         """
-        from dask.base import tokenize
         cat = cls(**kwargs)
         cat._entries = entries
-        cat._tok = tokenize(kwargs, entries)
         return cat
 
     @property

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -69,14 +69,15 @@ class CatalogEntry(DictSerialiseMixin):
             None, must be one of ['always', 'never', 'default']. Has no
             effect if the source has never been persisted, use source.persist()
         """
-        from ..container.persist import store
 
         if persist is not None and persist not in [
                 'always', 'never', 'default']:
             raise ValueError('Persist value (%s) not understood' % persist)
         persist = persist or self._pmode
         s = self.get(**kwargs)
-        if s.has_been_persisted and persist != 'never':
+        if persist != 'never' and s.has_been_persisted:
+            from ..container.persist import store
+
             s2 = s.get_persisted()
             met = s2.metadata
             if persist == 'always' or not met['ttl']:

--- a/intake/cli/server/tests/test_serializer.py
+++ b/intake/cli/server/tests/test_serializer.py
@@ -22,6 +22,7 @@ all_compressors = pytest.mark.parametrize(
 @all_serializers
 def test_dataframe(ser):
     pd = pytest.importorskip('pandas')
+    pytest.importorskip('pyarrow')
     csv_filename = os.path.join(os.path.dirname(__file__), 'entry1_1.csv')
     expected_df = pd.read_csv(csv_filename)
 

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -135,6 +135,9 @@ class TestServerV1Source(TestServerV1Base):
         self.assertEqual(resp_msg['description'], 'entry1 part')
 
     def test_read_part_compressed(self):
+        # because the msgpack format actually depends on pyarrow
+        pytest.importorskip('pyarrow')
+
         msg = dict(action='open', name='entry1', parameters={})
         resp_msg, = self.make_post_request(msg)
         source_id = resp_msg['source_id']
@@ -158,6 +161,8 @@ class TestServerV1Source(TestServerV1Base):
             self.assertEqual(len(data), 4)
 
     def test_read_partition(self):
+        # because the msgpack format actually depends on pyarrow
+        pytest.importorskip('pyarrow')
         msg = dict(action='open', name='entry1', parameters={})
         resp_msg, = self.make_post_request(msg)
         source_id = resp_msg['source_id']
@@ -242,7 +247,7 @@ def multi_server(tmpdir):
             break
         except:
             time.sleep(0.2)
-            if time.time() - t > 10: 
+            if time.time() - t > 10:
                 break
     P.terminate()
     P.wait()
@@ -268,7 +273,7 @@ def port_server(tmpdir):
             break
         except:
             time.sleep(0.2)
-            if time.time() - t > 10: 
+            if time.time() - t > 10:
                 break
     P.terminate()
     P.wait()
@@ -293,7 +298,7 @@ def address_server(tmpdir):
             break
         except:
             time.sleep(0.2)
-            if time.time() - t > 10: 
+            if time.time() - t > 10:
                 break
     P.terminate()
     P.wait()

--- a/intake/container/tests/test_persist.py
+++ b/intake/container/tests/test_persist.py
@@ -15,14 +15,16 @@ from intake.source.base import DataSource
 
 
 def test_store(temp_cache):
+    from dask.base import tokenize
     assert list(store) == []
     s = DataSource(metadata={'original_name': 'blah'})
-    store.add(s._tok, s)
+    token = tokenize(s)
+    store.add(token, s)
     time.sleep(0.2)
 
     store.ttl = 0
-    assert list(store) == [s._tok]
-    assert store.get_tok(s) == s._tok
+    assert list(store) == [token]
+    assert store.get_tok(s) == token
     assert store.needs_refresh(s) is False  # because it has no TTL
 
     store.remove(s)

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -94,7 +94,6 @@ class DictSerialiseMixin(object):
         from dask.base import tokenize
         warnings.warn("the _tok attribute is deprecated, please use "
                       "`dask.base.tokenize(obj)` instead")
-        raise Exception
         return tokenize(self)
 
     def __new__(cls, *args, **kwargs):

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -85,13 +85,24 @@ def classname(ob):
 
 
 class DictSerialiseMixin(object):
+
+    __tok_cache = None
+
+    @property
+    def _tok(self):
+        import warnings
+        from dask.base import tokenize
+        warnings.warn("the _tok attribute is deprecated, please use "
+                      "`dask.base.tokenize(obj)` instead")
+        raise Exception
+        return tokenize(self)
+
     def __new__(cls, *args, **kwargs):
         """Capture creation args when instantiating"""
-        from dask.base import tokenize
         o = object.__new__(cls)
         o._captured_init_args = args
         o._captured_init_kwargs = kwargs
-        o.__dict__['_tok'] = tokenize(o.__getstate__())
+
         return o
 
     @property
@@ -99,7 +110,10 @@ class DictSerialiseMixin(object):
         return classname(self)
 
     def __dask_tokenize__(self):
-        return hash(self)
+        if self.__tok_cache is None:
+            from dask.base import tokenize
+            self.__tok_cache = tokenize(self.__getstate__())
+        return self.__tok_cache
 
     def __getstate__(self):
         args = [arg.__getstate__() if isinstance(arg, DictSerialiseMixin)
@@ -125,7 +139,8 @@ class DictSerialiseMixin(object):
         self.__init__(*state['args'], **state['kwargs'])
 
     def __hash__(self):
-        return int(self._tok, 16)
+        from dask.base import tokenize
+        return int(tokenize(self), 16)
 
     def __eq__(self, other):
         return hash(self) == hash(other)


### PR DESCRIPTION
See the second commit messages for details, but by making this change (and by making sure we opt-out of persistence in our sub-classes) we are able to take the time it takes to init catalogs from ~5-10s to ~5us.

We are creating catalogs "on the fly" from data we already have in memory so all of the data payload is being injected via the arguments so we are just burning a tremendous amount of CPU upfront.

The way this was written we could not figure out any way to over-ride this behavior without compromising using `__getstate__` for pickle.

attn @danielballan @ronpandolfi 