### PR TITLE
Change source_id to source-id

### DIFF
--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -20,21 +20,21 @@ GET /info
 
 Retrieve information about the data-sets available on this server. The list of data-sets may be
 paginated, in order to avoid excessively long transactions. Notice that the catalog for which a listing
-is being requested can itself be a data-source (when ``source_id`` is passed) - this is how nested
+is being requested can itself be a data-source (when ``source-id`` is passed) - this is how nested
 sub-catalogs are handled on the server.
 
 Parameters
 ~~~~~~~~~~
 
 - ``page_size``, int or none (optional): to enable pagination, set this value. The number of entries returned
-  will be this value at most. If None, returns all entries.
+  will be this value at most. If None, returns all entries. This is passed as a query parameter.
 
 - ``page_offset``, int (optional): when paginating, start the list from this numerical offset. The order of entries
-  is guaranteed if the base catalog has not changed.
+  is guaranteed if the base catalog has not changed. This is passed as a query parameter.
 
-- ``source_id``, uuid string (optional): when the catalog being accessed is not the route catalog, but an open data-source
+- ``source-id``, uuid string (optional): when the catalog being accessed is not the route catalog, but an open data-source
   on the server, this is its unique identifier. See ``POST /source`` for how these IDs are generated.
-  If the catalog being accessed is the root Catalog, this parameter should be omitted.
+  If the catalog being accessed is the root Catalog, this parameter should be omitted. This is passed as an HTTP header.
 
 Returns
 ~~~~~~~
@@ -55,11 +55,11 @@ a particular data-source can be accessed without paginating through all of the s
 Parameters
 ~~~~~~~~~~
 
-- ``name``, string (required): the data source name being accessed, one of the members of the catalog
+- ``name``, string (required): the data source name being accessed, one of the members of the catalog. This is passed as a query parameter.
 
-- ``source_id``, uuid string (optional): when the catalog being accessed is not the root catalog, but an open data-source
+- ``source-id``, uuid string (optional): when the catalog being accessed is not the root catalog, but an open data-source
   on the server, this is its unique identifier. See ``POST /source`` for how these IDs are generated.
-  If the catalog being accessed is the root Catalog, this parameter should be omitted.
+  If the catalog being accessed is the root Catalog, this parameter should be omitted. This is passed as an HTTP header.
 
 Returns
 ~~~~~~~
@@ -76,12 +76,12 @@ Searching a Catalog returns search results in the form of a new Catalog. This
 Parameters
 ~~~~~~~~~~
 
-- ``source_id``, uuid string (optional): When the catalog being searched is not
+- ``source-id``, uuid string (optional): When the catalog being searched is not
   the root catalog, but a subcatalog on the server, this is its unique
   identifier. If the catalog being searched is the root Catalog, this parameter
-  should be omitted.
-- ``query``: tuple of ``(args, kwargs)``: These will be unpacked into
-  ``Catalog.search`` on the server to create the "results" Catalog.
+  should be omitted. This is passed as an HTTP header.
+- ``query``: tuple of ``(args, kwargs)``: These will be unpacked into 
+  ``Catalog.search`` on the server to create the "results" Catalog. This is passed in the body of the message.
 
 Returns
 ~~~~~~~
@@ -115,18 +115,19 @@ server and returning its UUID, such that a listing can be made using ``GET/ info
 Parameters
 ~~~~~~~~~~
 
-- ``name``, string (required): the data source name being accessed, one of the members of the catalog
+- ``name``, string (required): the data source name being accessed, one of the members of the catalog. This is passed in the body of the request.
 
-- ``source_id``, uuid string (optional): when the catalog being accessed is not the root catalog, but an open data-source
-  on the server, this is its unique identifier. If the catalog being accessed is the root Catalog, this parameter should be omitted.
+- ``source-id``, uuid string (optional): when the catalog being accessed is not the root catalog, but an open data-source
+  on the server, this is its unique identifier. If the catalog being accessed is the root Catalog, this parameter should be omitted. This
+  is passed as an HTTP header.
 
 - ``available_plugins``, list of string (optional): the set of named data drivers supported by the client. If the driver required
-  by the data-source is not supported by the client, then the source must be opened remote-access.
+  by the data-source is not supported by the client, then the source must be opened remote-access. This is passed in the body of the request.
 
 - ``parameters``, object (optional): user parameters to pass to the data-source when instantiating. Whether or not direct-access
   is possible may, in principle, depend on these parameters, but this is unlikely. Note that some parameter default
   value functions are designed to be evaluated on the server, which may have access to, for example, some credentials
-  service (see :ref:`paramdefs`).
+  service (see :ref:`paramdefs`). This is passed in the body of the request.
 
 Returns
 ~~~~~~~
@@ -143,14 +144,14 @@ This route fetches data from the server once a data-source has been opened in re
 
 Parameters
 ~~~~~~~~~~
-- ``source_id``, uuid string (required): the identifier of the data-source in the server's source cache. This is returned
-  when ``action="open"``.
+- ``source-id``, uuid string (required): the identifier of the data-source in the server's source cache. This is returned
+  when ``action="open"``. This is passed in the body of the request.
 
 - ``partition``, int or tuple (optional, but necessary for some sources): section/chunk of the data to fetch.
   In cases where the data-source is partitioned,
   the client will fetch the data one partition at a time, so that it will appear partitioned in the same manner on
   the client side for iteration of passing to Dask. Some data-sources do not support partitioning, and then this
-  parameter is not required/ignored.
+  parameter is not required/ignored. This is passed in the body of the request.
 
 - ``accepted_formats``, ``accepted_compression``, list of strings (required): to specify how serialization of data happens. This
-  is an expert feature, see docs in the module ``intake.container.serializer``.
+  is an expert feature, see docs in the module ``intake.container.serializer``. This is passed in the body of the request.

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -679,7 +679,7 @@ class RemoteCatalog(Catalog):
         """
         Return a copy of the http_args
 
-        Adds auth headers and 'source_id', merges in params.
+        Adds auth headers and 'source-id', merges in params.
         """
         # Add the auth headers to any other headers
         headers = self.http_args.get('headers', {})
@@ -690,7 +690,7 @@ class RemoteCatalog(Catalog):
         # build new http args with these headers
         http_args = self.http_args.copy()
         if self._source_id is not None:
-            headers['source_id'] = self._source_id
+            headers['source-id'] = self._source_id
         http_args['headers'] = headers
 
         # Merge in any params specified by the caller.

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -91,8 +91,8 @@ class ServerInfoHandler(tornado.web.RequestHandler):
         page_size = self.get_argument('page_size', None)
         page_offset = self.get_argument('page_offset', 0)
         if self.auth.allow_connect(head):
-            if 'source_id' in head:
-                cat = self.cache.get(head['source_id'])
+            if 'source-id' in head:
+                cat = self.cache.get(head['source-id'])
             else:
                 cat = self.catalog
             sources = []
@@ -199,8 +199,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
         head = self.request.headers
         name = self.get_argument('name')
         if self.auth.allow_connect(head):
-            if 'source_id' in head:
-                cat = self._cache.get(head['source_id'])
+            if 'source-id' in head:
+                cat = self._cache.get(head['source-id'])
             else:
                 cat = self._catalog
             try:
@@ -239,16 +239,16 @@ class ServerSourceHandler(tornado.web.RequestHandler):
         action = request['action']
         head = self.request.headers
         logger.debug('Source POST: %s' % request)
-
+        
         if action == 'search':
-            if 'source_id' in head:
-                cat = self._cache.get(head['source_id'])
+            if 'source-id' in head:
+                cat = self._cache.get(head['source-id'])
             else:
                 cat = self._catalog
             query = request['query']
             # Construct a cache key from the source_id of the Catalog being
             # searched and the query itself.
-            query_source_id = '-'.join((head.get('source_id', 'root'),
+            query_source_id = '-'.join((head.get('source-id', 'root'),
                                         str(query)))
             try:
                 cat = self._cache.get(query_source_id)
@@ -268,8 +268,8 @@ class ServerSourceHandler(tornado.web.RequestHandler):
             self.write(msgpack.packb(response, **pack_kwargs))
             self.finish()
         elif action == 'open':
-            if 'source_id' in head:
-                cat = self._cache.get(head['source_id'])
+            if 'source-id' in head:
+                cat = self._cache.get(head['source-id'])
             else:
                 cat = self._catalog
             entry_name = request['name']


### PR DESCRIPTION
Fixes https://github.com/intake/intake/issues/515

I think there's probably an opportunity to make parameter passing more consistent. I updated the documentation just to make it more clear how parameters are passed for each message...sometimes query parameters, sometimes in the body of the message and just in the case of source-id, as an http header. But that would be a greater fix than this, which simply fixes the issue of reverse proxies not passing HTTP headers that contain underscores.

I also tried to write some tests that exercise this, but I was unsure how write a test that loads something in the cache for a future request, which seems to be where source_id is really used.