### PR TITLE
Bump fsspec version to support simplecache::

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ numpy
 pyyaml
 requests
 msgpack
-fsspec >=0.3.6
+fsspec >=0.7.4


### PR DESCRIPTION
It appears that the `simplecache::` prefix for catalog URLs was added in to `fsspec` v0.7.4 (https://github.com/intake/filesystem_spec/commit/86047154765fe384be9bcfdd37fcfa04702f8bbe).
The `intake` documentation currently [suggests](https://github.com/intake/intake/blob/9c45a5749b5d4e6db00fe013ca56f381ece5f7b1/docs/source/catalog.rst#caching) using simplecache with catalogs, but that's not possible with the fsspec version currently included in `requirements.txt`. This commit bumps the `fsspec` version so that `simplecache::` is supported.