### PR TITLE
Add url signing as an alternative to forbid direct access

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -572,6 +572,10 @@ Whether a particular catalog entry supports direct or proxied access is determin
 - ``force``: Force all clients to access the data directly.  If they do not have the required driver, an exception will
   be raised.
 
+- ``signed``: Clients access the data directly, but are provided with a temporary URLs. This enables authentication
+  systems to still be effective without requiring the server to load all the data itself. Similar to ``force`` this
+  will raise an error if the client doesn't have the needed driver.
+
 Note that when the client is loading a data source via direct access, the catalog server will need to send the driver
 arguments to the client.  Do not include sensitive credentials in a data source that allows direct access.
 

--- a/intake/cli/server/server.py
+++ b/intake/cli/server/server.py
@@ -4,6 +4,7 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
+import datetime
 import time
 from uuid import uuid4
 
@@ -13,6 +14,7 @@ import msgpack
 import tornado.gen
 import tornado.ioloop
 import tornado.web
+from fsspec.utils import infer_storage_options
 
 from intake.config import conf
 from intake.container import serializer
@@ -319,7 +321,20 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                                      metadata=source.metadata))
                 self.write(msgpack.packb(response, **pack_kwargs))
                 self.finish()
-            elif direct_access == 'force' and not client_has_plugin:
+            elif direct_access == 'signed' and client_has_plugin:
+                response = open_desc
+                user_parameters['plugin'] = plugin_name
+                response['args'] = (entry._entry._create_open_args(user_parameters)[1])
+                signed_url = sign_url(response['args']['urlpath'])
+                if signed_url:
+                    response['args']['urlpath'] = signed_url
+                else:
+                    msg = 'server could not create signed url for "%s"' % entry_name
+                    raise tornado.web.HTTPError(status_code=400, log_message=msg,
+                                                reason=msg)
+                self.write(msgpack.packb(response, **pack_kwargs))
+                self.finish()
+            elif (direct_access in ['signed', 'force']) and not client_has_plugin:
                 msg = 'client must have plugin "%s" to access source "%s"' \
                       '' % (plugin_name, entry_name)
                 raise tornado.web.HTTPError(status_code=400, log_message=msg,
@@ -384,3 +399,32 @@ class ServerSourceHandler(tornado.web.RequestHandler):
                 compressor = serializer.compression_registry[f]
 
         return serializer.ComboSerializer(format_encoder, compressor)
+
+
+# Note that these functions assume that all the credentials are loaded properly
+def gcs_signer(path: str, host: str):
+    from google.cloud import storage
+    client = storage.Client()
+    bucket = client.bucket(host)
+    blob = bucket.blob(path.partition(host)[-1])
+    return blob.generate_signed_url(expiration=datetime.timedelta(minutes=5), method='GET')
+
+
+def s3_signer(path, host):
+    import boto3
+    client = boto3.client('s3')
+    return client.generate_presigned_url('s3',
+                                         Params={'Bucket': host,
+                                                 'Key': path.partition(host)[-1]},
+                                         ExpiresIn=datetime.timedelta(minutes=5).seconds)
+
+
+SIGNING_REGISTRY = {'s3': s3_signer,
+                    'gcs': gcs_signer,
+                    'gs': gcs_signer}
+
+
+def sign_url(url):
+    storage_md = infer_storage_options(url)
+    signing_function = SIGNING_REGISTRY[storage_md['protocol']]
+    return signing_function(storage_md['path'], storage_md['host'])


### PR DESCRIPTION
The idea here is that instead of having forbid direct access load the data on the server and send it over to the client, only for the client need to load it again we send over a signed URL.
These URLs have a limited access time, meaning that we don't leak permissions to the data in case of a credentialed server.

This PR isn't complete but I wanted to open this up so we could discuss how best to place the moving pieces into intake.