### PR TITLE
Template function to offset datetime parameter

### DIFF
--- a/intake/catalog/utils.py
+++ b/intake/catalog/utils.py
@@ -12,6 +12,7 @@ import os
 import re
 import shlex
 import subprocess
+import datetime
 import sys
 
 
@@ -70,6 +71,8 @@ def _j_passthrough(x, funcname):
         x = x._undefined_name
     return "{{%s(%s)}}" % (funcname, x)
 
+def _offset_datetime(x, *args, **kwargs):
+    return x + datetime.timedelta(*args, **kwargs)
 
 def _expand(p, context, all_vars, client, getenv, getshell):
     if isinstance(p, dict):
@@ -96,6 +99,7 @@ def _expand(p, context, all_vars, client, getenv, getshell):
             jinja.globals['client_shell'] = _j_getshell
         else:
             jinja.globals['client_shell'] = lambda x: _j_passthrough(x, funcname='client_shell')
+        jinja.globals['offset_datetime'] = _offset_datetime
         ast = jinja.parse(p)
         all_vars -= meta.find_undeclared_variables(ast)
         return jinja.from_string(p).render(context)


### PR DESCRIPTION
I have a opendap server where the files are stored with a time-span in the filename which is always one hour apart, for example
`LIDAR_obs_09291300_09291400.nc` 
i.e. the format is 
`LIDAR_obs_{{t_start.strftime("%m%d%H%M")}}_{{t_end.strftime("%m%d%H%M")}}.nc`

It would be nice to have the user just provide `t_start` (which I can then check for validity) and then calculate `t_end` from it (`t_end = t_start + datetime.timedelta(hours=1)`). I appreciate that allowing for custom functions would open a whole can of worms, but maybe adding a specialised jinja template function for offsetting datetimes might be useful. I've created one called `offset_datetime` write
`LIDAR_obs_{{t_start.strftime("%m%d%H%M")}}_{{offset_datetime(t_start, hours=1).strftime("%m%d%H%M")}}.nc`

Would this be something you would consider adding to `intake`?