### PR TITLE
FIX: defer pulling from entry points and specialer case intake.cat

### DIFF
--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -19,7 +19,6 @@ from .source import register_driver, registry
 imports = {
     "DataSource": "intake.source.base:DataSource",
     'Schema': "intake.source.base:Schema",
-    "cat": "intake.catalog:builtin",
     "load_combo_catalog": "intake.catalog.default:load_combo_catalog",
     "upload": "intake.container:upload",
     "gui": "intake.interface:instance",
@@ -58,6 +57,11 @@ def __getattr__(attr):
                 gl[attr] = getattr(mod, dest.split(":")[1])
             else:
                 gl[attr] = mod
+        if attr == 'cat':
+            mod = importlib.import_module('intake.catalog')
+            if mod.builtin is None:
+                mod.builtin = mod._make_builtin()
+            gl['cat'] = mod.builtin
     if attr == "__all__":
         return __dir__()
     try:

--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -22,6 +22,7 @@ imports = {
     "load_combo_catalog": "intake.catalog.default:load_combo_catalog",
     "upload": "intake.container:upload",
     "gui": "intake.interface:instance",
+    "cat": "intake.catalog:builtin",
     "output_notebook": "intake.interface:output_notebook",
     "register_driver": "intake.source:register_driver",
     "unregister_driver": "intake.source:unregister_driver",
@@ -57,11 +58,6 @@ def __getattr__(attr):
                 gl[attr] = getattr(mod, dest.split(":")[1])
             else:
                 gl[attr] = mod
-        if attr == 'cat':
-            mod = importlib.import_module('intake.catalog')
-            if mod.builtin is None:
-                mod.builtin = mod._make_builtin()
-            gl['cat'] = mod.builtin
     if attr == "__all__":
         return __dir__()
     try:

--- a/intake/catalog/__init__.py
+++ b/intake/catalog/__init__.py
@@ -9,10 +9,18 @@ from .base import Catalog
 from .local import MergedCatalog, EntrypointsCatalog
 from .default import load_combo_catalog
 
-builtin = None
 
 def _make_builtin():
     return MergedCatalog(
         [EntrypointsCatalog(), load_combo_catalog()],
         name='builtin',
         description='Generated from data packages found on your intake search path')
+
+
+def __getattr__(name):
+    """Only make the builtin catalog on request"""
+    global builtin
+    if name == "builtin":
+        builtin = _make_builtin()
+        return builtin
+    raise AttributeError(name)

--- a/intake/catalog/__init__.py
+++ b/intake/catalog/__init__.py
@@ -9,7 +9,10 @@ from .base import Catalog
 from .local import MergedCatalog, EntrypointsCatalog
 from .default import load_combo_catalog
 
-builtin = MergedCatalog(
-    [EntrypointsCatalog(), load_combo_catalog()],
-    name='builtin',
-    description='Generated from data packages found on your intake search path')
+builtin = None
+
+def _make_builtin():
+    return MergedCatalog(
+        [EntrypointsCatalog(), load_combo_catalog()],
+        name='builtin',
+        description='Generated from data packages found on your intake search path')

--- a/intake/catalog/tests/test_discovery.py
+++ b/intake/catalog/tests/test_discovery.py
@@ -2,6 +2,7 @@ import copy
 import glob
 import os
 import pytest
+import sys
 
 from ..local import YAMLFilesCatalog, MergedCatalog, EntrypointsCatalog
 
@@ -16,3 +17,19 @@ def test_catalog_discovery():
 
     assert 'use_example1' in test_catalog
     assert 'ep1' in test_catalog
+
+
+def test_deferred_import():
+    "See https://github.com/intake/intake/pull/541"
+    # We are going to mess with sys.modules here, so to be safe let's put it
+    # back the way it was at the end.
+    modules = sys.modules.copy()
+    del sys.modules["intake"]
+    try:
+        import intake
+        assert intake.catalog is None
+        assert intake.cat is not None
+        assert intake.catalog is not None  # implementation detail
+    finally:
+        # Put sys.modules back as it was before we messed with it.
+        sys.modules = modules

--- a/intake/catalog/tests/test_discovery.py
+++ b/intake/catalog/tests/test_discovery.py
@@ -23,13 +23,14 @@ def test_deferred_import():
     "See https://github.com/intake/intake/pull/541"
     # We are going to mess with sys.modules here, so to be safe let's put it
     # back the way it was at the end.
-    modules = sys.modules.copy()
-    del sys.modules["intake"]
+    import intake.catalog
+    intake.catalog.builtin = None
+    mods = sys.modules.copy()
     try:
-        import intake
-        assert intake.catalog is None
+        sys.modules.pop("intake")
+        sys.modules.pop("intake.catalog")
+        intake.catalog.__dict__.pop('builtin')
+        assert 'builtin' not in intake.catalog.__dict__
         assert intake.cat is not None
-        assert intake.catalog is not None  # implementation detail
     finally:
-        # Put sys.modules back as it was before we messed with it.
-        sys.modules = modules
+        sys.modules.update(mods)


### PR DESCRIPTION
If the entrypoints found code that was in turn imported intake.catalog
then, because of the user of `__getattr__` in `intake/__init__.py` the
downstream libraries would fail to import and get see an
AttributeError.

This change defers filling the entry points until the user actually
asks for `intake.cat`, not just importing `intake.catalog`.