### PR TITLE
Expect entry or source to implement 'container' but not '_container'.

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -385,7 +385,7 @@ class Catalog(DataSource):
             e = self._entries[key]
             e._catalog = self
             e._pmode = self.pmode
-            if e._container == 'catalog':
+            if e.container == 'catalog':
                 return e(name=key)
             return e()
         if isinstance(key, str) and '.' in key:

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -664,6 +664,16 @@ def test_filter():
     assert cat2.trial2 == entry2()
 
 
+def test_from_dict_with_data_source():
+    "Check that Catalog.from_dict accepts DataSources not wrapped in Entry."
+    from intake.catalog.base import Catalog
+    fn = os.path.join(tempfile.mkdtemp(), 'mycat.yaml')
+    entry = LocalCatalogEntry(name='trial', description='get this back',
+                              driver='csv', args=dict(urlpath=""))
+    ds = entry()
+    cat = Catalog.from_dict({'trial': ds}, name='mycat')
+
+
 def test_no_instance():
     from intake.catalog.local import LocalCatalogEntry
 


### PR DESCRIPTION
Closes #545 

This turned out to be an easy fix: just rely on the public API instead of the private one. The intake tests pass without changes. Likewise, the databroker tests pass against this branch with no workarounds. This PR also incidentally enables

```py
Catalog.from_dict({'thing': CSVSource(...)})
```

without wrapping `CSVSource(...)` in an `Entry`, which fits our goal of "Let users never see Entry objects" as @martindurant put it in #490. I added a test to exercise that usage.