### PR TITLE
Fix category ordering for path column

### DIFF
--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -96,12 +96,6 @@ class CSVSource(base.DataSource, base.PatternMixin):
                 **self._csv_kwargs)
             return
 
-        if not (DASK_VERSION >= '0.19.0'):
-            raise ValueError("Your version of dask is '{}'. "
-                "The ability to include filenames in read_csv output "
-                "(``include_path_column``) was added in 0.19.0, so "
-                "pattern urlpaths are not supported.".format(DASK_VERSION))
-
         drop_path_column = 'include_path_column' not in self._csv_kwargs
         path_column = self._path_column()
 

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -58,20 +58,14 @@ class CSVSource(base.DataSource, base.PatternMixin):
     def _set_pattern_columns(self, path_column):
         """Get a column of values for each field in pattern
         """
-        try:
-            # CategoricalDtype allows specifying known categories when
-            # creating objects. It was added in pandas 0.21.0.
-            from pandas.api.types import CategoricalDtype
-            _HAS_CDT = True
-        except ImportError:
-            _HAS_CDT = False
+        from pandas.api.types import CategoricalDtype
 
         col = self._dataframe[path_column]
-        paths = col.cat.categories
+        paths = sorted(col.cat.categories)
 
         column_by_field = {field:
             col.cat.codes.map(dict(enumerate(values))).astype(
-                "category" if not _HAS_CDT else CategoricalDtype(set(values))
+                CategoricalDtype(set(values))
             ) for field, values in reverse_formats(self.pattern, paths).items()
         }
         self._dataframe = self._dataframe.assign(**column_by_field)

--- a/intake/source/utils.py
+++ b/intake/source/utils.py
@@ -212,6 +212,7 @@ def reverse_format(format_string, resolved_string):
 
     return args
 
+
 def path_to_glob(path):
     """
     Convert pattern style paths to glob style paths
@@ -255,6 +256,7 @@ def path_to_glob(path):
             glob += '*'
         prev_field_name = field_name
     return glob
+
 
 def path_to_pattern(path, metadata=None):
     """


### PR DESCRIPTION
This likely works around a dask bug for include_path_column , that the category columns don't end up in the same order as the file paths (which are sorted by fsspec). I'm not sure is dask is supposed to guarantee the order (cc @jsignell )

Ref #559 - this is causing the failures.

