### PR TITLE
add shape and dtype properties to ZarrArraySource

### DIFF
--- a/intake/source/tests/test_npy.py
+++ b/intake/source/tests/test_npy.py
@@ -66,6 +66,8 @@ def test_zarr_minimal():
     cat = intake.open_catalog(posixpath.join(here, 'sources.yaml'))
     s = cat.zarr1()
     assert s.container == 'ndarray'
-    assert s.read().tolist() == [73, 98, 46, 38, 20, 12, 31,  8, 89, 72]
+    assert s.read().tolist() == [73, 98, 46, 38, 20, 12, 31, 8, 89, 72]
     assert s.npartitions == 1
+    assert s.dtype == 'int'
+    assert s.shape == (10,)
     assert (s.read_partition((0, )) == s.read()).all()

--- a/intake/source/zarr.py
+++ b/intake/source/zarr.py
@@ -43,6 +43,9 @@ class ZarrArraySource(DataSource):
         self.storage_options = storage_options or {}
         self.component = component
         self.kwargs = kwargs
+        self.shape = None
+        self.dtype = None
+        self.chunks = None
         self._arr = None
         super(ZarrArraySource, self).__init__(metadata=metadata)
 
@@ -53,6 +56,8 @@ class ZarrArraySource(DataSource):
                                      storage_options=self.storage_options,
                                      **self.kwargs)
             self.chunks = self._arr.chunks
+            self.shape = self._arr.shape
+            self.dtype = self._arr.dtype
             self.npartitions = self._arr.npartitions
         return Schema(dtype=str(self.dtype), shape=self.shape,
                       extra_metadata=self.metadata,

--- a/intake/source/zarr.py
+++ b/intake/source/zarr.py
@@ -43,8 +43,6 @@ class ZarrArraySource(DataSource):
         self.storage_options = storage_options or {}
         self.component = component
         self.kwargs = kwargs
-        self.shape = None
-        self.dtype = None
         self.chunks = None
         self._arr = None
         super(ZarrArraySource, self).__init__(metadata=metadata)


### PR DESCRIPTION
`ZarrArraySource` now has `shape` and `dtype` properties which default to `None` and are set to the respective properties of the underlying `_arr` after creating the dask array wrapping the zarr array. The one test for `ZarrArraySource` now checks for these properties.
