### PR TITLE
Add  jinja2 to requirements.txt?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ dask
 entrypoints
 pyyaml
 fsspec >=0.7.4
+jinja2


### PR DESCRIPTION
Hi,

I'm not sure, if this is the right place to report and fix a dependency issue.
But I got the error `ModuleNotFoundError: No module named 'jinja2'` after installing intake 0.6.1 and importing it in Python 3.6.7.

best
Marek