### PR TITLE
Fix nested catalog access

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -412,7 +412,7 @@ class Catalog(DataSource):
         elif isinstance(key, tuple):
             out = self
             for part in key:
-                out = self[part]
+                out = out[part]
             return out()
         raise KeyError(key)
 

--- a/intake/tests/catalog_nested.yml
+++ b/intake/tests/catalog_nested.yml
@@ -1,0 +1,6 @@
+sources:
+  nested:
+    description: References catalog_nested_sub.yml
+    driver: yaml_file_cat
+    args:
+      path: "{{ CATALOG_DIR }}__unit_test_catalog_nested_sub.yml"

--- a/intake/tests/catalog_nested_sub.yml
+++ b/intake/tests/catalog_nested_sub.yml
@@ -1,0 +1,6 @@
+sources:
+  ex1:
+    description: this is a sub-resource
+    driver: csv
+    args:
+      urlpath: ""

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -134,3 +134,20 @@ def test_no_imports():
     for mod in ['intake.tests', 'intake.interface', 'intake.source.csv',
                 'intake.cli', 'intake.auth']:
         assert mod not in sys.modules
+
+
+@pytest.fixture
+def tmp_path_catalog_nested():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = posixpath.join(tmp_dir, 'intake')
+        target_catalog = copy_test_file('catalog_nested.yml', tmp_path)
+        copy_test_file('catalog_nested_sub.yml', tmp_path)
+        yield target_catalog
+
+
+def test_nested_catalog_access(tmp_path_catalog_nested):
+    cat = intake.open_catalog(tmp_path_catalog_nested)
+    entry1 = cat.nested.ex1
+    entry2 = cat["nested.ex1"]
+    entry3 = cat["nested", "ex1"]
+    assert entry1 == entry2 == entry3

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -149,5 +149,6 @@ def test_nested_catalog_access(tmp_path_catalog_nested):
     cat = intake.open_catalog(tmp_path_catalog_nested)
     entry1 = cat.nested.ex1
     entry2 = cat["nested.ex1"]
-    entry3 = cat["nested", "ex1"]
-    assert entry1 == entry2 == entry3
+    entry3 = cat[["nested", "ex1"]]
+    entry4 = cat["nested", "ex1"]
+    assert entry1 == entry2 == entry3 == entry4


### PR DESCRIPTION
I noticed in __getitem__ that a tuple-style method of accessing nested entries is supposed to work, but it does not.

For example:
`catalog.root.leaf` works fine, but `catalog["root", "leaf"]` fails with a KeyError. This PR is meant to cause the latter behavior to work as stated in the __getitem__ docstring.