### PR TITLE
convert classes to strings during serialization

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -276,8 +276,11 @@ class Catalog(DataSource):
             kw = entry._captured_init_kwargs.copy()
             kw.pop('catalog', None)
             kw['parameters'] = {k.name: k.__getstate__()['kwargs'] for k in kw.get('parameters', [])}
-            if issubclass(kw['driver'], DataSourceBase):
-                kw['driver'] = ".".join([kw['driver'].__module__, kw['driver'].__name__])
+            try:
+                if issubclass(kw['driver'], DataSourceBase):
+                    kw['driver'] = ".".join([kw['driver'].__module__, kw['driver'].__name__])
+            except TypeError:
+                pass # ignore exception for a string input
             output["sources"][key] = kw
         return yaml.dump(output)
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -276,6 +276,8 @@ class Catalog(DataSource):
             kw = entry._captured_init_kwargs.copy()
             kw.pop('catalog', None)
             kw['parameters'] = {k.name: k.__getstate__()['kwargs'] for k in kw.get('parameters', [])}
+            if not isinstance(kw['driver'], str):
+                kw['driver'] = str(kw['driver']).split("'")[1]
             output["sources"][key] = kw
         return yaml.dump(output)
 

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -10,7 +10,7 @@ import logging
 import re
 import time
 
-from ..source.base import DataSource, NoEntry
+from ..source.base import DataSource, NoEntry, DataSourceBase
 from .utils import reload_on_change
 
 logger = logging.getLogger('intake')
@@ -276,8 +276,8 @@ class Catalog(DataSource):
             kw = entry._captured_init_kwargs.copy()
             kw.pop('catalog', None)
             kw['parameters'] = {k.name: k.__getstate__()['kwargs'] for k in kw.get('parameters', [])}
-            if not isinstance(kw['driver'], str):
-                kw['driver'] = str(kw['driver']).split("'")[1]
+            if issubclass(kw['driver'], DataSourceBase):
+                kw['driver'] = ".".join([kw['driver'].__module__, kw['driver'].__name__])
             output["sources"][key] = kw
         return yaml.dump(output)
 


### PR DESCRIPTION
Closes #608 

I tried using `kw['driver'].__name__`, but it output only "NetCDFSource".
Similarly, `kw['driver'].__class__.__name__` and `type(kw['driver'])` output "type" rather than "intake_xarray.netcdf.NetCDFSource". I figured this may be a common issue with other drivers not having registered names and thus went with the non-breaking solution. Happy to change it if there's a better solution.