### PR TITLE
Allow user parameters throughout catalog

### DIFF
--- a/docs/source/catalog.rst
+++ b/docs/source/catalog.rst
@@ -294,7 +294,7 @@ Parameter Definition
 --------------------
 
 Source parameters
-~~~~~~~~~~~~~~~~~
+'''''''''''''''''
 
 A source definition can contain a "parameters" block.
 Expressed in YAML, a parameter may look as follows:
@@ -333,7 +333,7 @@ Note: the ``datetime`` type accepts multiple values:
 Python datetime, ISO8601 string,  Unix timestamp int, "now" and  "today".
 
 Catalog parameters
-~~~~~~~~~~~~~~~~~~
+''''''''''''''''''
 
 You can also define user parameters at the catalog level. This applies the parameter to
 all entries within that catalog, without having to define it for each and every entry.
@@ -361,7 +361,7 @@ For example, with the following spec
         path: "{{CATALOG_DIR}}/other.yaml"
 
 If ``cat`` is the corresponsing catalog instance,
-the URL of source ``cat.param_source`` will evaluate to "s3://test_bucket/file.parquet", but
+the URL of source ``cat.param_source`` will evaluate to "s3://test_bucket/file.parquet" by default, but
 the parameter can be overridden with ``cat.param_source(bucket="other_bucket")``. Also, any
 entries of ``subcat``, another catalog referenced from here, would also have the "bucket"-named
 parameter attached to all sources. Of course, those sources do no need to make use of the

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -319,7 +319,7 @@ class Catalog(DataSource):
         up_names = set((up["name"] if isinstance(up, dict) else up.name)
                         for up in entry._user_parameters)
         ups = [up for name, up in self.user_parameters.items() if name not in up_names]
-        entry._user_parameters = ups + entry._user_parameters
+        entry._user_parameters = ups + (entry._user_parameters or [])
         return entry()
 
     def configure_new(self, **kwargs):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -692,10 +692,10 @@ class YAMLFileCatalog(Catalog):
 
         self._entries = {}
         shared_parameters = data.get("metadata", {}).get("parameters", {})
-        self.user_parameters = {
+        self.user_parameters.update({
             name: UserParameter(name, **attrs)
             for name, attrs in shared_parameters.items()
-        }
+        })
 
         for entry in cfg['data_sources']:
             entry._catalog = self

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -803,23 +803,6 @@ def test_cat_dictlike(catalog1):
     assert list(catalog1.items()) == list(zip(catalog1.keys(), catalog1.values()))
 
 
-@pytest.fixture
-def inherit_params_cat():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = posixpath.join(tmp_dir, "intake")
-        target_catalog = copy_test_file("catalog_inherit_params.yml", tmp_path)
-        return open_catalog(target_catalog)
-
-
-@pytest.fixture
-def inherit_params_multiple_cats():
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_path = posixpath.join(tmp_dir, "intake")
-        copy_test_file("catalog_inherit_params.yml", tmp_path)
-        copy_test_file("catalog_nested_sub.yml", tmp_path)
-        return open_catalog(tmp_path + "/*.yml")
-
-
 def test_inherit_params(inherit_params_cat):
     assert inherit_params_cat.param._urlpath == "s3://test_bucket/file.parquet"
 

--- a/intake/catalog/tests/test_parameters.py
+++ b/intake/catalog/tests/test_parameters.py
@@ -217,3 +217,7 @@ def test_unknown():
                           parameters=[up])
     s = e()
     assert s.kwargs['arg1'] == ""
+
+
+def test_catalog_passthrough(inherit_params_cat):
+    pass

--- a/intake/catalog/tests/test_parameters.py
+++ b/intake/catalog/tests/test_parameters.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import intake
 from intake.catalog.local import LocalCatalogEntry, UserParameter
 from intake.source.base import DataSource
 
@@ -219,5 +220,18 @@ def test_unknown():
     assert s.kwargs['arg1'] == ""
 
 
-def test_catalog_passthrough(inherit_params_cat):
-    pass
+def test_catalog_passthrough():
+    root = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    cat = intake.open_catalog(os.path.join(root, "tests/catalog_inherit_params.yml"))
+    assert set(cat.subcat.user_parameters) == {"bucket", "inner"}
+    url = cat.subcat.ex2.urlpath
+    assert url == "test_bucket/test_name"
+    url = cat.subcat.ex2(bucket="hi", inner="ho").urlpath
+    assert url == "hi/ho"
+
+    # test clone
+    cat2 = cat(bucket="yet")
+    url = cat2.subcat(inner="another").ex2.urlpath
+    assert url == "yet/another"
+    url = cat2.subcat(inner="another").ex2(bucket="hi").urlpath
+    assert url == "hi/another"

--- a/intake/catalog/tests/test_reload_integration.py
+++ b/intake/catalog/tests/test_reload_integration.py
@@ -45,9 +45,9 @@ sources:
     description: example1 source plugin
     driver: example1
     args: {}
-        ''')
+''')
 
-    time.sleep(2)
+    time.sleep(1)
 
     yield intake_server
     os.remove(fullname)
@@ -59,22 +59,13 @@ def test_reload_updated_config(intake_server_with_config):
     entries = list(catalog)
     assert entries == ['use_example1']
 
-    with open(os.path.join(TMP_DIR, YAML_FILENAME), 'w') as f:
+    with open(os.path.join(TMP_DIR, YAML_FILENAME), 'a') as f:
         f.write('''
-plugins:
-  source:
-    - module: intake.catalog.tests.example1_source
-    - module: intake.catalog.tests.example_plugin_dir.example2_source
-sources:
-  use_example1:
-    description: example1 source plugin
-    driver: example1
-    args: {}
   use_example1_1:
     description: example1 other
     driver: example1
     args: {}
-        ''')
+''')
 
     time.sleep(1.2)
 

--- a/intake/conftest.py
+++ b/intake/conftest.py
@@ -9,15 +9,18 @@ import os
 import subprocess
 import time
 
+import posixpath
 import pytest
 import requests
+import tempfile
 
-from intake import config
+from intake import config, open_catalog
 from intake.container import persist
 from intake.util_tests import ex, PY2
 from intake.utils import make_path_posix
 from intake.source.base import DataSource, Schema
 from intake import register_driver
+from intake.tests.test_utils import copy_test_file
 
 here = os.path.dirname(__file__)
 
@@ -201,3 +204,20 @@ def env(temp_cache, tempdir):
     env["INTAKE_CONF_DIR"] = intake.config.confdir
     env['INTAKE_CACHE_DIR'] = intake.config.conf['cache_dir']
     return env
+
+
+@pytest.fixture
+def inherit_params_cat():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = posixpath.join(tmp_dir, "intake")
+        target_catalog = copy_test_file("catalog_inherit_params.yml", tmp_path)
+        return open_catalog(target_catalog)
+
+
+@pytest.fixture
+def inherit_params_multiple_cats():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = posixpath.join(tmp_dir, "intake")
+        copy_test_file("catalog_inherit_params.yml", tmp_path)
+        copy_test_file("catalog_nested_sub.yml", tmp_path)
+        return open_catalog(tmp_path + "/*.yml")

--- a/intake/conftest.py
+++ b/intake/conftest.py
@@ -221,3 +221,12 @@ def inherit_params_multiple_cats():
         copy_test_file("catalog_inherit_params.yml", tmp_path)
         copy_test_file("catalog_nested_sub.yml", tmp_path)
         return open_catalog(tmp_path + "/*.yml")
+
+
+@pytest.fixture
+def inherit_params_subcat():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = posixpath.join(tmp_dir, "intake")
+        target_catalog = copy_test_file("catalog_inherit_params.yml", tmp_path)
+        copy_test_file("catalog_nested_sub.yml", tmp_path)
+        return open_catalog(target_catalog)

--- a/intake/tests/catalog_inherit_params.yml
+++ b/intake/tests/catalog_inherit_params.yml
@@ -32,3 +32,12 @@ sources:
         default: local_filename.parquet
     args:
       urlpath: s3://{{bucket}}/{{filename}}
+  subcat:
+    driver: yaml_file_cat
+    args:
+      path: "{{CATALOG_DIR}}/catalog_nested_sub.yml"
+      user_parameters:
+        inner:
+          type: str
+          description: description
+          default: test_name

--- a/intake/tests/catalog_nested_sub.yml
+++ b/intake/tests/catalog_nested_sub.yml
@@ -8,4 +8,4 @@ sources:
     description: this is a sub-resource
     driver: csv
     args:
-      urlpath: "{{test_bucket}}/{{test_name}}"
+      urlpath: "{{bucket}}/{{inner}}"

--- a/intake/tests/catalog_nested_sub.yml
+++ b/intake/tests/catalog_nested_sub.yml
@@ -4,3 +4,8 @@ sources:
     driver: csv
     args:
       urlpath: ""
+  ex2:
+    description: this is a sub-resource
+    driver: csv
+    args:
+      urlpath: "{{test_bucket}}/{{test_name}}"


### PR DESCRIPTION
Currently, catalog-level parameters are established as an argument `user_parameters=` to `Catalog`, or a block in the YAML file:
```
metadata:
  parameters:
    var_name:
      type: str
      description: description
      default: something
```



(requires documentation and tests)