### PR TITLE
Config / registry

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -530,7 +530,8 @@ def register_plugin_module(mod):
         if k:
             if isinstance(k, (list, tuple)):
                 k = k[0]
-            register_driver(k, v)
+            # we clobber by default here
+            register_driver(k, v, clobber=True)
 
 
 def get_dir(path):
@@ -888,5 +889,5 @@ class EntrypointsCatalog(Catalog):
 # Register these early in the import process to support the default catalog
 # which is built at import time. (Without this, 'yaml_file_cat' is looked for
 # in intake.registry before the registry has been populated.)
-register_driver('yaml_file_cat', YAMLFileCatalog)
-register_driver('yaml_files_cat', YAMLFilesCatalog)
+register_driver('yaml_file_cat', YAMLFileCatalog, clobber=True)
+register_driver('yaml_files_cat', YAMLFilesCatalog, clobber=True)

--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -480,7 +480,7 @@ def open_remote(url, entry, container, user_parameters, description, http_args,
     payload = dict(action='open',
                    name=entry,
                    parameters=user_parameters,
-                   available_plugins=list(plugin_registry.keys()))
+                   available_plugins=list(plugin_registry))
     req = requests.post(urljoin(url, '/v1/source'),
                         data=msgpack.packb(payload, **pack_kwargs),
                         **http_args)

--- a/intake/cli/client/subcommands/config.py
+++ b/intake/cli/client/subcommands/config.py
@@ -74,6 +74,6 @@ class Config(Subcommand):
         print(yaml.dump(defaults, default_flow_style=False))
 
     def _reset(self, args):
-        from intake.config import reset_conf, save_conf
-        reset_conf()
-        save_conf()
+        from intake.config import conf
+        conf.reset()
+        conf.save()

--- a/intake/conftest.py
+++ b/intake/conftest.py
@@ -53,7 +53,7 @@ def tmp_config_path(tmp_path):
     os.environ[key] = temp_config_path
     assert config.cfile() == temp_config_path
     yield temp_config_path
-    config.reset_conf()
+    config.conf.reset()
     if original:
         os.environ[key] = original
     else:
@@ -187,7 +187,7 @@ def temp_cache(tempdir):
     intake.config.conf.update({'cache_dir': make_path_posix(str(tempdir)),
                                'cache_download_progress': False,
                                'cache_disabled': False})
-    intake.config.save_conf()
+    intake.config.conf.save()
     store.__init__(os.path.join(tempdir, 'persist'))
     try:
         yield

--- a/intake/tests/test_config.py
+++ b/intake/tests/test_config.py
@@ -11,8 +11,10 @@ import requests
 
 import intake
 from intake import config
+from intake.config import Config, defaults
 from intake.util_tests import temp_conf, server
 from intake.catalog.remote import RemoteCatalog
+
 
 @pytest.mark.parametrize('conf', [
     {},
@@ -21,14 +23,15 @@ from intake.catalog.remote import RemoteCatalog
 ])
 def test_load_conf(conf):
     # This test will only work if your config is set to default
-    inconf = config.defaults.copy()
+    inconf = defaults.copy()
     expected = inconf.copy()
     with temp_conf(conf) as fn:
-        config.load_conf(fn)
+        config = Config(fn)
+        config.load(fn)
         expected.update(conf)
-        assert config.conf == expected
-        config.reset_conf()
-        assert config.conf == inconf
+        assert dict(config) == expected
+        config.reset()
+        assert dict(config) == inconf
 
 
 # Tests with a real separate server process

--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -45,7 +45,7 @@ def tmp_path_catalog():
 
 
 def test_autoregister_open():
-    assert hasattr(intake, 'open_csv')
+    assert intake.open_csv
 
 
 def test_default_catalogs():

--- a/intake/util_tests.py
+++ b/intake/util_tests.py
@@ -7,7 +7,6 @@
 
 from contextlib import contextmanager
 import os
-import posixpath
 import requests
 import shutil
 import subprocess


### PR DESCRIPTION
Trying to greatly simplify the config and driver registry systems, in particular not to have separate paths for registering drivers via the CLI versus via code.

@danielballan , this is largely stepping on your previous attempt to retialise these things. We could take this opportunity to remove package scanning altogether.

Ref #635 