### PR TITLE
fixing issue where .add does not return updates

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -655,10 +655,7 @@ class YAMLFileCatalog(Catalog):
         with file_open as f:
             yaml.dump(data, f, default_flow_style=False)
 
-        if path:
-            return self
-        else:
-            return YAMLFileCatalog(self.path, storage_options=storage_options,
+        return YAMLFileCatalog(path or self.path, storage_options=storage_options,
                                    autoreload=self.autoreload)
 
     def parse(self, text):


### PR DESCRIPTION
`LocalCatalogEntry` `.add` function does not return the updated object when a new path is specified. Docstring says to expect new Catalog returned when a file path is passed.