### PR TITLE
BUG: allow None as json compression

### DIFF
--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -40,8 +40,8 @@ class JSONFileSource(DataSource):
             common
         compression : str or None
             If given, decompress the file with the given codec on load. Can
-            be something like "zip", "gzip", "bz2", or to try to guess from the
-            filename, 'infer'
+            be something like "zip", "gzip", "bz2", "xz". To try to guess from the
+            filename use "infer".
         storage_options: dict
             Options to pass to the file reader backend, including text-specific
             encoding arguments, and parameters specific to the remote
@@ -49,7 +49,7 @@ class JSONFileSource(DataSource):
         """
         from fsspec.utils import compressions
 
-        VALID_COMPRESSIONS = list(compressions.values()) + ["infer"]
+        VALID_COMPRESSIONS = list(compressions.values()) + ["infer", None]
 
         self._urlpath = urlpath
         self._storage_options = storage_options or {}
@@ -57,7 +57,7 @@ class JSONFileSource(DataSource):
         self._file = None
         self.compression = compression
 
-        if compression not in VALID_COMPRESSIONS:
+        if compression not in VALID_COMPRESSIONS or None:
             raise ValueError(
                 f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
             )
@@ -123,7 +123,7 @@ class JSONLinesFileSource(DataSource):
         """
         from fsspec.utils import compressions
 
-        VALID_COMPRESSIONS = list(compressions.values()) + ["infer"]
+        VALID_COMPRESSIONS = list(compressions.values()) + ["infer", None]
 
         self._urlpath = urlpath
         self._storage_options = storage_options or {}

--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -22,7 +22,7 @@ class JSONFileSource(DataSource):
         urlpath: str,
         text_mode: bool = True,
         text_encoding: str = "utf8",
-        compression: str = "infer",
+        compression: str = None,
         read: bool = True,
         metadata: dict = None,
         storage_options: dict = None,
@@ -38,9 +38,10 @@ class JSONFileSource(DataSource):
         text_encoding : str
             If text_mode is True, apply this encoding. UTF* is by far the most
             common
-        compression : str
-            decompress the file with the given codec on load. Can
-            be something like "zip", "gzip", "bz2", "xz". Defualt "infer".
+        compression : str or None
+            If given, decompress the file with the given codec on load. Can
+            be something like "zip", "gzip", "bz2", or to try to guess from the
+            filename, 'infer'
         storage_options: dict
             Options to pass to the file reader backend, including text-specific
             encoding arguments, and parameters specific to the remote
@@ -55,11 +56,11 @@ class JSONFileSource(DataSource):
         self._dataframe = None
         self._file = None
         self.compression = compression
-
-        if compression not in VALID_COMPRESSIONS:
-            raise ValueError(
-                f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
-            )
+        if compression is not None:
+            if compression not in VALID_COMPRESSIONS:
+                raise ValueError(
+                    f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
+                )
         self.mode = "rt" if text_mode else "rb"
         self.encoding = text_encoding
         self._read = read
@@ -95,7 +96,7 @@ class JSONLinesFileSource(DataSource):
         urlpath: str,
         text_mode: bool = True,
         text_encoding: str = "utf8",
-        compression: str = "infer",
+        compression: str = None,
         read: bool = True,
         metadata: dict = None,
         storage_options: dict = None,
@@ -111,9 +112,10 @@ class JSONLinesFileSource(DataSource):
         text_encoding : str
             If text_mode is True, apply this encoding. UTF* is by far the most
             common
-        compression : str
-            decompress the file with the given codec on load. Can
-            be something like "zip", "gzip", "bz2", "xz". Defualt "infer".
+        compression : str or None
+            If given, decompress the file with the given codec on load. Can
+            be something like "zip", "gzip", "bz2", or to try to guess from the
+            filename, 'infer'.
         storage_options: dict
             Options to pass to the file reader backend, including text-specific
             encoding arguments, and parameters specific to the remote
@@ -128,10 +130,11 @@ class JSONLinesFileSource(DataSource):
         self._dataframe = None
         self._file = None
         self.compression = compression
-        if compression not in VALID_COMPRESSIONS:
-            raise ValueError(
-                f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
-            )
+        if compression is not None:
+            if compression not in VALID_COMPRESSIONS:
+                raise ValueError(
+                    f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
+                )
         self.mode = "rt" if text_mode else "rb"
         self.encoding = text_encoding
         self._read = read

--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -95,7 +95,7 @@ class JSONLinesFileSource(DataSource):
         urlpath: str,
         text_mode: bool = True,
         text_encoding: str = "utf8",
-        compression: str = None,
+        compression: str = "infer",
         read: bool = True,
         metadata: dict = None,
         storage_options: dict = None,
@@ -111,10 +111,9 @@ class JSONLinesFileSource(DataSource):
         text_encoding : str
             If text_mode is True, apply this encoding. UTF* is by far the most
             common
-        compression : str or None
-            If given, decompress the file with the given codec on load. Can
-            be something like "zip", "gzip", "bz2", or to try to guess from the
-            filename, 'infer'.
+        compression : str
+            decompress the file with the given codec on load. Can
+            be something like "zip", "gzip", "bz2", "xz". Defualt "infer".
         storage_options: dict
             Options to pass to the file reader backend, including text-specific
             encoding arguments, and parameters specific to the remote
@@ -122,7 +121,7 @@ class JSONLinesFileSource(DataSource):
         """
         from fsspec.utils import compressions
 
-        VALID_COMPRESSIONS = list(compressions.values()) + ["infer", None]
+        VALID_COMPRESSIONS = list(compressions.values()) + ["infer"]
 
         self._urlpath = urlpath
         self._storage_options = storage_options or {}

--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -56,7 +56,7 @@ class JSONFileSource(DataSource):
         self._file = None
         self.compression = compression
 
-        if compression not in VALID_COMPRESSIONS or None:
+        if compression not in VALID_COMPRESSIONS:
             raise ValueError(
                 f"Compression value {compression} must be one of {VALID_COMPRESSIONS}"
             )

--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -22,7 +22,7 @@ class JSONFileSource(DataSource):
         urlpath: str,
         text_mode: bool = True,
         text_encoding: str = "utf8",
-        compression: str = None,
+        compression: str = "infer",
         read: bool = True,
         metadata: dict = None,
         storage_options: dict = None,
@@ -38,10 +38,9 @@ class JSONFileSource(DataSource):
         text_encoding : str
             If text_mode is True, apply this encoding. UTF* is by far the most
             common
-        compression : str or None
-            If given, decompress the file with the given codec on load. Can
-            be something like "zip", "gzip", "bz2", "xz". To try to guess from the
-            filename use "infer".
+        compression : str
+            decompress the file with the given codec on load. Can
+            be something like "zip", "gzip", "bz2", "xz". Defualt "infer".
         storage_options: dict
             Options to pass to the file reader backend, including text-specific
             encoding arguments, and parameters specific to the remote
@@ -49,7 +48,7 @@ class JSONFileSource(DataSource):
         """
         from fsspec.utils import compressions
 
-        VALID_COMPRESSIONS = list(compressions.values()) + ["infer", None]
+        VALID_COMPRESSIONS = list(compressions.values()) + ["infer"]
 
         self._urlpath = urlpath
         self._storage_options = storage_options or {}

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -43,8 +43,9 @@ def jsonl_file(request, tmp_path) -> str:
     return file_path
 
 
-def test_jsonfile(json_file: str):
-    j = JSONFileSource(json_file, text_mode=True, compression="infer")
+@pytest.mark.parametrize("compression", ["infer", None])
+def test_jsonfile(json_file: str, compression):
+    j = JSONFileSource(json_file, text_mode=True, compression=compression)
     out = j.read()
     assert isinstance(out, dict)
     assert out["hello"] == "world"

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -44,14 +44,28 @@ def jsonl_file(request, tmp_path) -> str:
 
 
 def test_jsonfile(json_file: str):
-    j = JSONFileSource(json_file, text_mode=True)
+    j = JSONFileSource(json_file, text_mode=True, compression="infer")
     out = j.read()
     assert isinstance(out, dict)
     assert out["hello"] == "world"
 
 
+def test_jsonfile_none(json_file: str):
+    try:
+        j = JSONFileSource(json_file, text_mode=True, compression=None)
+        out = j.read()
+        # compression=None should not raise exception for uncompressed files
+        assert json_file.endswith(".json")
+    except UnicodeDecodeError:
+        # compression=None should raise exception for compressed files
+        assert not json_file.endswith(".json")
+        return
+    assert isinstance(out, dict)
+    assert out["hello"] == "world"
+
+
 def test_jsonlfile(jsonl_file: str):
-    j = JSONLinesFileSource(jsonl_file)
+    j = JSONLinesFileSource(jsonl_file, compression="infer")
     out = j.read()
     assert isinstance(out, list)
 
@@ -62,8 +76,27 @@ def test_jsonlfile(jsonl_file: str):
     assert out[1] == [1, 2, 3]
 
 
+def test_jsonfilel_none(jsonl_file: str):
+    try:
+        j = JSONFileSource(jsonl_file, compression=None)
+        out = j.read()
+        # compression=None should not raise exception for uncompressed files
+        assert jsonl_file.endswith(".jsonl")
+    except UnicodeDecodeError:
+        # compression=None should raise exception for compressed files
+        assert not jsonl_file.endswith(".jsonl")
+        return
+    assert isinstance(out, list)
+
+    assert isinstance(out[0], dict)
+    assert out[0]["hello"] == "world"
+
+    assert isinstance(out[1], list)
+    assert out[1] == [1, 2, 3]
+
+
 def test_jsonl_head(jsonl_file: str):
-    j = JSONLinesFileSource(jsonl_file)
+    j = JSONLinesFileSource(jsonl_file, compression="infer")
     out = j.head(1)
     assert isinstance(out, list)
     assert len(out) == 1

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -43,9 +43,8 @@ def jsonl_file(request, tmp_path) -> str:
     return file_path
 
 
-@pytest.mark.parametrize("compression", ["infer", None])
-def test_jsonfile(json_file: str, compression):
-    j = JSONFileSource(json_file, text_mode=True, compression=compression)
+def test_jsonfile(json_file: str):
+    j = JSONFileSource(json_file, text_mode=True)
     out = j.read()
     assert isinstance(out, dict)
     assert out["hello"] == "world"

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -78,7 +78,7 @@ def test_jsonlfile(jsonl_file: str):
 
 def test_jsonfilel_none(jsonl_file: str):
     try:
-        j = JSONFileSource(jsonl_file, compression=None)
+        j = JSONLinesFileSource(jsonl_file, compression=None)
         out = j.read()
         # compression=None should not raise exception for uncompressed files
         assert jsonl_file.endswith(".jsonl")

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -51,7 +51,7 @@ def test_jsonfile(json_file: str):
 
 
 def test_jsonlfile(jsonl_file: str):
-    j = JSONLinesFileSource(jsonl_file, compression="infer")
+    j = JSONLinesFileSource(jsonl_file)
     out = j.read()
     assert isinstance(out, list)
 
@@ -63,7 +63,7 @@ def test_jsonlfile(jsonl_file: str):
 
 
 def test_jsonl_head(jsonl_file: str):
-    j = JSONLinesFileSource(jsonl_file, compression="infer")
+    j = JSONLinesFileSource(jsonl_file)
     out = j.head(1)
     assert isinstance(out, list)
     assert len(out) == 1


### PR DESCRIPTION
If you have a json without compression, you would use the default of None.

However, this will currently raise a `ValueError` as None is not in `VALID_COMPRESSIONS`.
https://github.com/intake/intake/blob/master/intake/source/jsonfiles.py#L60

This PR fixes this by also checking for a None value.

cc. @blackary 

Don't think CI failures are related.