### PR TITLE
use ValueError instead of TypeError in test_mlist_parameter

### DIFF
--- a/intake/catalog/tests/test_parameters.py
+++ b/intake/catalog/tests/test_parameters.py
@@ -173,7 +173,7 @@ def test_mlist_parameter():
         up.validate(["c"])
     with pytest.raises(ValueError):
         up.validate(["a", "c"])
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         up.validate("hello")
 
 


### PR DESCRIPTION
Closes https://github.com/intake/intake/issues/645

Looking at https://github.com/intake/intake/commit/bc1d43524f9f0c38ccc5285d1f3fa02c37339372#diff-fba7c89fec707e3f51c2564d024b1feeff479f8bd9d5fad3f503544b2afb88df

The function used to return a `TypeError` but now returns a `ValueError`