### PR TITLE
fixed description issue

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -282,7 +282,7 @@ class Catalog(DataSource):
         """
         import yaml
         output = {"metadata": self.metadata, "sources": {},
-                  "name": self.name}
+                  "name": self.name, "description": self.description}
         for key, entry in self._entries.items():
             kw = entry._captured_init_kwargs.copy()
             kw.pop('catalog', None)

--- a/intake/catalog/tests/test_catalog_save.py
+++ b/intake/catalog/tests/test_catalog_save.py
@@ -1,0 +1,28 @@
+"""
+Test saving catalogs.
+"""
+
+import intake
+from intake.catalog import Catalog
+from intake.catalog.local import LocalCatalogEntry
+
+
+def test_catalog_description():
+    """Make sure the description comes through the save."""
+
+    cat1 = Catalog.from_dict({
+                'name': LocalCatalogEntry('name',
+                                          description='description',
+                                          driver=intake.catalog.local.YAMLFileCatalog,
+                                            )
+    },
+                name='overall catalog name',
+                description='overall catalog description'
+
+    )
+
+    cat1.save('desc_test.yaml')
+
+    cat2 = intake.open_catalog('desc_test.yaml')
+
+    assert cat2.description is not None


### PR DESCRIPTION
When saving an overall catalog, the description would not transfer. Now it does.
Also added a test to check for this.