### PR TITLE
Fix missing bullets in Sphinx docs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - hvplot >=0.5.2
   - panel >=0.8.0
   - bokeh <2.0.0
+  - docutils <0.17  # Downgrade docutils to fix missing bullets (https://stackoverflow.com/a/68008428)
   - sphinx
   - sphinx_rtd_theme
   - numpydoc


### PR DESCRIPTION
The documentation is currently missing bullet points on the index page. Based on this [StackOverflow answer](https://stackoverflow.com/a/68008428), downgrading `docutils` to `<0.17` appears to have resolved this for my local Sphinx build.

Live:

![image](https://user-images.githubusercontent.com/11037737/157084207-376d5cfa-f54b-4bde-829f-39d4793de178.png)

Local:

![image](https://user-images.githubusercontent.com/11037737/157084467-901f1924-bb7e-4b59-8164-03eb52a69f62.png)
