### PR TITLE
add changelog for 0.6.5 and next release

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,28 @@
+Changelog
+=========
+
+.. _v0.6.6:
+
+0.6.6
+-----
+
+Released on MONTH DAYNUM, YEAR.
+
+- Fixed bug in json and jsonl driver.
+- Ensure description is retained in the catalog.
+- Fix cache issue when running inside a notebook.
+- Add templating parameters.
+- Plotting api keeps hold of hvplot calls to allow other plots to be made.
+
+.. _v0.6.5:
+
+0.6.5
+-----
+
+Released on January 9, 2022.
+
+- Added link to intake-google-analytics.
+- Add tiled driver.
+- Add json and jsonl drivers.
+- Allow parameters to be passed through catalog.
+- Add mlist type which allows inputs from a known list of values.

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -6,6 +6,7 @@ Reference
     :maxdepth: 1
 
     api.rst
+    changelog.rst
     making-plugins.rst
     auth-plugins.rst
     data-packages.rst


### PR DESCRIPTION
Closes #640 

While working on the notes for 0.6.5 it was natural for me to work on the next release.

Welcome to push any changes that give a better overview of the PRs.