### PR TITLE
Update references to collections for consistency and clarity

### DIFF
--- a/docs/source/deployments.rst
+++ b/docs/source/deployments.rst
@@ -64,14 +64,14 @@ across multiple (of the order ~300,000) netCDF files. Finding, investigating, lo
 such as `xarray` can be a daunting task due to the large number of files a user may be interested in.
 ``Intake-esm`` addresses this issue in three steps:
 
-- `Datasets Collection Curation`_ in form of YAML files. These YAML files provide information about data locations,
+- `Dataset Catalog Curation`_ in form of YAML files. These YAML files provide information about data locations,
   access pattern,  directory structure, etc. ``intake-esm`` uses these YAML files in conjunction with file name templates
   to construct a local database. Each row in this database consists of a set of metadata such as ``experiment``,
   ``modeling realm``, ``frequency`` corresponding to data contained in one netCDF file.
 
 .. code-block:: python
 
-   col = intake.open_esm_metadatastore(collection_input_definition="GLADE-CMIP5")
+   cat = intake.open_esm_metadatastore(catalog_input_definition="GLADE-CMIP5")
 
 
 - Search and Discovery: once the database is built, ``intake-esm`` can be used for searching and discovering
@@ -80,7 +80,7 @@ such as `xarray` can be a daunting task due to the large number of files a user 
 
 .. code-block:: python
 
-   cat = col.search(variable=['hfls'], frequency='mon', modeling_realm='atmos', institute=['CCCma', 'CNRM-CERFACS'])
+   sub_cat = cat.search(variable=['hfls'], frequency='mon', modeling_realm='atmos', institute=['CCCma', 'CNRM-CERFACS'])
 
 - Access: when the user is satisfied with the results of their query, they can ask ``intake-esm``
   to load the actual netCDF files into xarray datasets:
@@ -90,7 +90,7 @@ such as `xarray` can be a daunting task due to the large number of files a user 
    dsets = cat.to_xarray(decode_times=True, chunks={'time': 50})
 
 .. _intake-esm: https://github.com/NCAR/intake-esm
-.. _Datasets Collection Curation: https://github.com/NCAR/intake-esm-datastore
+.. _Datasets Catalog Curation: https://github.com/NCAR/intake-esm-datastore
 .. _Coupled Model Intercomparison Project (CMIP): https://www.wcrp-climate.org/wgcm-cmip
 .. _Community Earth System Model (CESM) Large Ensemble Project: http://www.cesm.ucar.edu/projects/community-projects/LENS/
 
@@ -98,7 +98,7 @@ Brookhaven Archive
 ~~~~~~~~~~~~~~~~~~
 
 The `Bluesky`_ project uses Intake to dynamically query a MongoDB instance, which
-holds the details of experimental and simulation data collections, to return a
+holds the details of experimental and simulation data catalogs, to return a
 custom Catalog for every query. Data-sets can then be loaded into python, or the original
 raw data can be accessed ...
 

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -14,7 +14,7 @@ Glossary
         format of the files is unchanged in this case, but may be decompressed.
 
     Catalog
-        A collection of entries, each of which corresponds to a specific :term:`Data-set`. Within these docs, a catalog is
+        An inventory of entries, each of which corresponds to a specific :term:`Data-set`. Within these docs, a catalog is
         most commonly defined in a :term:`YAML` file, for simplicity, but there are other possibilities, such as connecting to an Intake
         server or another third-party data service, like a SQL database. Thus, catalogs form a hierarchy: any
         catalog can contain other, nested catalogs.
@@ -41,7 +41,7 @@ Glossary
         Pandas data-frame.
 
     Data-set
-        A specific collection of data. The type of data (tabular, multi-dimensional or something else) and the format
+        A specific assemblage of data. The type of data (tabular, multi-dimensional or something else) and the format
         (file type, data service type) are all attributes of the data-set. In addition, in the context of Intake,
         data-sets are usually entries within a :term:`Catalog` with additional descriptive text and metadata and
         a specification of *how* to load the data.

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -69,7 +69,7 @@ Intake is built out of four core concepts:
 * Data Source: An object that represents a reference to a data source.  Data source instances have methods for loading the
   data into standard containers, like Pandas DataFrames, but do not load any data until specifically requested.
 
-* Catalog: A collection of catalog entries, each of which defines a Data Source. Catalog objects can be created from
+* Catalog: An inventory of catalog entries, each of which defines a Data Source. Catalog objects can be created from
   local YAML definitions, by connecting
   to remote servers, or by some driver that knows how to query an external data service.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -110,7 +110,7 @@ working with Dask collections (Bag, Array or Data-frames).
 Opening a Catalog
 -----------------
 
-A :term:`Catalog` is a collection of data sources, with the type and arguments prescribed for each, and
+A :term:`Catalog` is an inventory of data sources, with the type and arguments prescribed for each, and
 arbitrary metadata about each source.
 In the simplest case, a catalog can be described by a file in YAML format, a
 ":term:`Catalog file`". In real usage, catalogues can be defined in a number of ways, such as remote

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -24,7 +24,7 @@ class Catalog(DataSource):
     directory of files). This can be expanded to include a
     collection of subcatalogs, which are then managed as a single unit.
 
-    A catalog is created with a single URI or a collection of URIs. A URI can
+    A catalog is created with a single URI or a group of URIs. A URI can
     either be a URL or a file path.
 
     Each catalog in the hierarchy is responsible for caching the most recent


### PR DESCRIPTION
There are some name space collisions with "collections" vs "catalogs". Originally a catalog was defined using the term "collection", but now there is a "Collection" class. To reduce confusion, I have replaced references to collections with similar terms (catalog when appropriate, inventory, group, etc). 

This effort has been made in `intake-esm` too, and thus references to `intake-esm` in this documentation that used th term "collection" erroneously were out-of-date.

See discussion on https://github.com/intake/intake-esm/pull/457 with @andersy005 
