### PR TITLE
fix: removes leading slash for urljoin

### DIFF
--- a/intake/catalog/remote.py
+++ b/intake/catalog/remote.py
@@ -481,7 +481,7 @@ def open_remote(url, entry, container, user_parameters, description, http_args,
                    name=entry,
                    parameters=user_parameters,
                    available_plugins=list(plugin_registry))
-    req = requests.post(urljoin(url, '/v1/source'),
+    req = requests.post(urljoin(url, 'v1/source'),
                         data=msgpack.packb(payload, **pack_kwargs),
                         **http_args)
     if req.ok:

--- a/intake/container/base.py
+++ b/intake/container/base.py
@@ -47,7 +47,7 @@ class RemoteSource(DataSource):
         if self._source_id is None:
             payload = dict(action='open', name=self.name,
                            parameters=self.parameters)
-            req = requests.post(urljoin(self.url, '/v1/source'),
+            req = requests.post(urljoin(self.url, 'v1/source'),
                                 data=msgpack.packb(payload, **pack_kwargs),
                                 **self.headers)
             req.raise_for_status()
@@ -103,7 +103,7 @@ def get_partition(url, headers, source_id, container, partition):
         payload['partition'] = partition
 
     try:
-        resp = requests.post(urljoin(url, '/v1/source'),
+        resp = requests.post(urljoin(url, 'v1/source'),
                              data=msgpack.packb(payload, **pack_kwargs),
                              **headers)
         if resp.status_code != 200:


### PR DESCRIPTION
Hosting the intake server behind a reverse proxy at a non-standard address leads to mangling of the actual URLs. I am unsure if this fix covers all cases, but the URLs are now correctly translated for my case.

Here is an extracted basic example:

```python
>>> from urllib.parse import urljoin
>>> base_url = "http://server.org/intake/"
>>> bad_url = urljoin(base_url, "/v1/source")
>>> good_url = urljoin(base_url, "v1/source")
>>> print(f"{bad_url=}, {good_url=}")
bad_url='http://server.org/v1/source', good_url='http://server.org/intake/v1/source'
```
