### PR TITLE
Add additional methods to json drivers

### DIFF
--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -173,3 +173,9 @@ class JSONLinesFileSource(DataSource):
         """
         with self._open() as f:
             return list(map(json.loads, islice(f, nrows)))
+
+    def _load_metadata(self):
+        pass
+
+    def _get_schema(self):
+        pass

--- a/intake/source/jsonfiles.py
+++ b/intake/source/jsonfiles.py
@@ -80,6 +80,12 @@ class JSONFileSource(DataSource):
         ) as f:
             return json.load(f)
 
+    def _load_metadata(self):
+        pass
+
+    def _get_schema(self):
+        pass
+
 
 class JSONLinesFileSource(DataSource):
     """

--- a/intake/source/tests/test_json.py
+++ b/intake/source/tests/test_json.py
@@ -64,6 +64,12 @@ def test_jsonfile_none(json_file: str):
     assert out["hello"] == "world"
 
 
+def test_jsonfile_discover(json_file: str):
+    j = JSONFileSource(json_file, text_mode=True, compression=None)
+    schema = j.discover()
+    assert schema == {'dtype': None, 'shape': None, 'npartitions': 0, 'metadata': {}}
+
+
 def test_jsonlfile(jsonl_file: str):
     j = JSONLinesFileSource(jsonl_file, compression="infer")
     out = j.read()
@@ -93,6 +99,12 @@ def test_jsonfilel_none(jsonl_file: str):
 
     assert isinstance(out[1], list)
     assert out[1] == [1, 2, 3]
+
+
+def test_jsonfilel_discover(json_file: str):
+    j = JSONLinesFileSource(jsonl_file, compression=None)
+    schema = j.discover()
+    assert schema == {'dtype': None, 'shape': None, 'npartitions': 0, 'metadata': {}}
 
 
 def test_jsonl_head(jsonl_file: str):


### PR DESCRIPTION
In an attempt to fix #673 this PR implements the methods `_load_metadata` and `_get_schema` to the JSON source classes.

ToDo
- [x] implement pseudo methods
- [x] tests for pseudo methods
- [ ] infer an actual scheme by reading a few rows of the JSON as suggested in https://github.com/intake/intake/issues/673#issuecomment-1181746450