### PR TITLE
Add CSV output to intake get CLI

### DIFF
--- a/docs/source/tools.rst
+++ b/docs/source/tools.rst
@@ -248,7 +248,7 @@ Get
 '''
 
 Given the name of a catalog entry, this subcommand outputs the entire data
-source to standard output.
+source to standard output as CSV.
 
 ::
 

--- a/intake/cli/client/subcommands/get.py
+++ b/intake/cli/client/subcommands/get.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 #-----------------------------------------------------------------------------
 
 # Standard library imports
+import sys
 
 # External imports
 
@@ -28,7 +29,7 @@ from intake.cli.util import Subcommand
 #-----------------------------------------------------------------------------
 
 class Get(Subcommand):
-    ''' Get a catalog entry
+    ''' Get a catalog entry as CSV
 
     '''
 
@@ -37,8 +38,14 @@ class Get(Subcommand):
     def initialize(self):
         self.parser.add_argument('uri', metavar='URI', type=str, help='Catalog URI')
         self.parser.add_argument('name', metavar='NAME', type=str, help='Catalog name')
+        self.parser.add_argument('--output', metavar='FILE', type=str, help='Output file')
 
     def invoke(self, args):
         catalog = open_catalog(args.uri)
         with catalog[args.name] as f:
-            print(f.read())
+            df = f.read()
+            if args.output:
+                out = args.output
+            else:
+                out = sys.stdout
+            df.to_csv(out, index=False)

--- a/intake/cli/client/subcommands/get.py
+++ b/intake/cli/client/subcommands/get.py
@@ -22,7 +22,7 @@ import sys
 
 # Intake imports
 from intake import open_catalog
-from intake.cli.util import Subcommand
+from intake.cli.util import Subcommand, die
 
 #-----------------------------------------------------------------------------
 # API
@@ -43,9 +43,14 @@ class Get(Subcommand):
     def invoke(self, args):
         catalog = open_catalog(args.uri)
         with catalog[args.name] as f:
-            df = f.read()
+            result = f.read()
+
+            if not hasattr(result, 'to_csv'):
+                die("Catalog entry doesn't support CSV output")
+
             if args.output:
                 out = args.output
             else:
                 out = sys.stdout
-            df.to_csv(out, index=False)
+
+            result.to_csv(out, index=False)


### PR DESCRIPTION
This small change adds the ability to get CSV output from the `intake get` CLI . Previously it was printing out the string representation of a DataFrame. It also adds a `--output` option for writing to a file instead of stdout.

Closes #684
