### PR TITLE
allow for ttl being None

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -169,7 +169,7 @@ class Catalog(DataSource):
 
     def reload(self):
         """Reload catalog if sufficient time has passed"""
-        if time.time() - self.updated > self.ttl:
+        if (self.ttl is not None) and (time.time() - self.updated > self.ttl):
             self.force_reload()
 
     @property


### PR DESCRIPTION
I saw in the docs that TTL can be None to not expire, but if a user selects that there is an error. This small change allows for TTL=None.