### PR TITLE
fix deprecation for distutils Version classes

### DIFF
--- a/intake/source/utils.py
+++ b/intake/source/utils.py
@@ -5,10 +5,10 @@
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 try:
     import dask
-    DASK_VERSION = LooseVersion(dask.__version__)
+    DASK_VERSION = Version(dask.__version__)
 except:
     DASK_VERSION = None
 from ..utils import make_path_posix


### PR DESCRIPTION
Was getting

```
  /Users/ray/miniforge3/envs/main/lib/python3.9/site-packages/intake/source/utils.py:11: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    DASK_VERSION = LooseVersion(dask.__version__)
```

Copied the solution in xarray https://github.com/pydata/xarray/pull/6096/files