### PR TITLE
Move msgpack_numpy import so tests can pass if not installed

### DIFF
--- a/intake/cli/server/tests/test_serializer.py
+++ b/intake/cli/server/tests/test_serializer.py
@@ -34,6 +34,7 @@ def test_dataframe(ser):
 
 @all_serializers
 def test_ndarray(ser):
+    pytest.importorskip('msgpack_numpy')
     expected_array = np.arange(35).reshape((5, 7))
 
     # Check roundtrip

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -257,6 +257,9 @@ def multi_server(tmpdir):
     shutil.rmtree(tmpdir)
 
 
+# If this tests fails on Mac running Monterey or newer,
+# Look at this solution to Apple using port 5000:
+# https://developer.apple.com/forums/thread/682332
 def test_flatten_flag(multi_server):
     cat = open_catalog(multi_server)
     assert list(cat) == ['cat1', 'cat2']

--- a/intake/container/serializer.py
+++ b/intake/container/serializer.py
@@ -59,8 +59,8 @@ class MsgPackSerializer(object):
     name = 'msgpack'
 
     def encode(self, obj, container):
-        from ..compat import np_pack_kwargs
         if container in ['ndarray', 'xarray'] and msgpack_numpy:
+            from ..compat import np_pack_kwargs
             return msgpack.packb(obj, **np_pack_kwargs)
         elif container == 'dataframe':
             # Use pyarrow for serializing DataFrames, rather than


### PR DESCRIPTION
When running tests, I didn't have `msgpack_numpy` installed and tests failed.

This PR moves one import to avoid the error and skips a test when `msgpack_numpy`
is not installed.

It also adds a note to one test that I ran into on a new Mac. This is not a bug in the test,
but took me a while to figure out the root cause (Mac was stealing the default port for
use by AirPlay Receiver).