### PR TITLE
Fix bug in GUI when customizing a new plot

### DIFF
--- a/intake/__init__.py
+++ b/intake/__init__.py
@@ -24,6 +24,7 @@ imports = {
     "load_combo_catalog": "intake.catalog.default:load_combo_catalog",
     "upload": "intake.container:upload",
     "gui": "intake.interface:instance",
+    "interface": "intake.interface",
     "cat": "intake.catalog:builtin",
     "output_notebook": "intake.interface:output_notebook",
     "register_driver": "intake.source:register_driver",
@@ -101,12 +102,12 @@ def open_catalog(uri=None, **kwargs):
 
     The default behaviour if not specifying the driver is as follows:
 
-    - if ``uri`` is a a single string ending in "yml" or "yaml", open it as a
+    - if ``uri`` is a single string ending in "yml" or "yaml", open it as a
       catalog file
     - if ``uri`` is a list of strings, a string containing a glob character
       ("*") or a string not ending in "y(a)ml", open as a set of catalog
       files. In the latter case, assume it is a directory.
-    - if ``uri`` beings with protocol ``"intake:"``, connect to a remote
+    - if ``uri`` begins with protocol ``"intake:"``, connect to a remote
       Intake server
     - if ``uri`` is ``None`` or missing, create a base Catalog object without entries.
 

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -562,14 +562,16 @@ class YAMLFileCatalog(Catalog):
         ----------
         path: str
             Location of the file to parse (can be remote)
-        text: str
+        text: str (DEPRECATED)
             YAML contents of catalog, takes precedence over path
-        reload : bool
+        autoreload : bool
             Whether to watch the source file for changes; make False if you want
             an editable Catalog
         """
         self.path = path
-        if text:
+        if text is not None:
+            logger.warning("YAMLFileCatalog `text` argument is deprecated")
+            warnings.warn("`text` argument is deprecated", DeprecationWarning)
             self.parse(text)
             self.autoreload = False
         else:

--- a/intake/catalog/tests/test_catalog_save.py
+++ b/intake/catalog/tests/test_catalog_save.py
@@ -1,7 +1,7 @@
 """
 Test saving catalogs.
 """
-
+import os
 import intake
 from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry
@@ -9,6 +9,8 @@ from intake.catalog.local import LocalCatalogEntry
 
 def test_catalog_description():
     """Make sure the description comes through the save."""
+
+    NAME = 'desc_test.yaml'
 
     cat1 = Catalog.from_dict({
                 'name': LocalCatalogEntry('name',
@@ -21,8 +23,10 @@ def test_catalog_description():
 
     )
 
-    cat1.save('desc_test.yaml')
+    cat1.save(NAME)
 
-    cat2 = intake.open_catalog('desc_test.yaml')
+    cat2 = intake.open_catalog(NAME)
 
     assert cat2.description is not None
+
+    os.remove(NAME)

--- a/intake/catalog/tests/test_catalog_save.py
+++ b/intake/catalog/tests/test_catalog_save.py
@@ -7,10 +7,11 @@ from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry
 
 
-def test_catalog_description():
+def test_catalog_description(tmpdir):
     """Make sure the description comes through the save."""
 
-    NAME = 'desc_test.yaml'
+    tmpdir = str(tmpdir)
+    cat_path = os.path.join(tmpdir, 'desc_test.yaml')
 
     cat1 = Catalog.from_dict({
                 'name': LocalCatalogEntry('name',
@@ -23,10 +24,8 @@ def test_catalog_description():
 
     )
 
-    cat1.save(NAME)
+    cat1.save(cat_path)
 
-    cat2 = intake.open_catalog(NAME)
+    cat2 = intake.open_catalog(cat_path)
 
     assert cat2.description is not None
-
-    os.remove(NAME)

--- a/intake/cli/server/tests/test_serializer.py
+++ b/intake/cli/server/tests/test_serializer.py
@@ -34,6 +34,7 @@ def test_dataframe(ser):
 
 @all_serializers
 def test_ndarray(ser):
+    pytest.importorskip('msgpack_numpy')
     expected_array = np.arange(35).reshape((5, 7))
 
     # Check roundtrip

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -257,6 +257,9 @@ def multi_server(tmpdir):
     shutil.rmtree(tmpdir)
 
 
+# If this tests fails on Mac running Monterey or newer,
+# Look at this solution to Apple using port 5000:
+# https://developer.apple.com/forums/thread/682332
 def test_flatten_flag(multi_server):
     cat = open_catalog(multi_server)
     assert list(cat) == ['cat1', 'cat2']

--- a/intake/container/serializer.py
+++ b/intake/container/serializer.py
@@ -59,8 +59,8 @@ class MsgPackSerializer(object):
     name = 'msgpack'
 
     def encode(self, obj, container):
-        from ..compat import np_pack_kwargs
         if container in ['ndarray', 'xarray'] and msgpack_numpy:
+            from ..compat import np_pack_kwargs
             return msgpack.packb(obj, **np_pack_kwargs)
         elif container == 'dataframe':
             # Use pyarrow for serializing DataFrames, rather than

--- a/intake/interface/__init__.py
+++ b/intake/interface/__init__.py
@@ -34,9 +34,9 @@ def do_import():
 
 
 def __getattr__(attr):
-    if attr == 'instance':
+    if attr in {'instance', 'gui'}:
         do_import()
-    return gl['instance']
+    return gl[attr]
 
 
 def output_notebook(inline=True, logo=False):

--- a/intake/interface/source/defined_plots.py
+++ b/intake/interface/source/defined_plots.py
@@ -138,7 +138,7 @@ class Plots(BaseView):
     def interact(self, _):
         # "customize" was pressed
         if self.selected == 'None':
-            kwargs = {}
+            kwargs = {'y': []}
         else:
             kwargs = self.source.metadata['plots'][self.selected]
         if self.source.container == 'dataframe':


### PR DESCRIPTION
For the dataframe container, attempting to "customize" a new plot resulted in a KeyError inside `dfviz`. This fixes the issue.

Additionally, this PR allows the GUI to be opened for the non-builtin dataset prior to calling `intake.gui`.
This will now work:
```
import intake
ds = intake.open_catalog(...)
intake.interface.gui.GUI([ds])
```