### PR TITLE
Editable plots!

### DIFF
--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -74,7 +74,7 @@ class CatalogEntry(DictSerialiseMixin):
                 'always', 'never', 'default']:
             raise ValueError('Persist value (%s) not understood' % persist)
         persist = persist or self._pmode
-        s = self.get(**kwargs)  # Should this live in an `else` below the `if`?
+        s = self.get(**kwargs)
         if persist != 'never' and isinstance(s, PersistMixin) and s.has_been_persisted:
             from ..container.persist import store
 

--- a/intake/catalog/entry.py
+++ b/intake/catalog/entry.py
@@ -74,7 +74,7 @@ class CatalogEntry(DictSerialiseMixin):
                 'always', 'never', 'default']:
             raise ValueError('Persist value (%s) not understood' % persist)
         persist = persist or self._pmode
-        s = self.get(**kwargs)
+        s = self.get(**kwargs)  # Should this live in an `else` below the `if`?
         if persist != 'never' and isinstance(s, PersistMixin) and s.has_been_persisted:
             from ..container.persist import store
 

--- a/intake/container/dataframe.py
+++ b/intake/container/dataframe.py
@@ -4,7 +4,7 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 from intake.source.base import Schema, DataSource
@@ -38,7 +38,7 @@ class RemoteDataFrame(RemoteSource):
                 self.url, self.headers, self._source_id, self.container, i
             )
                           for i in range(self.npartitions)]
-            if LooseVersion(dask.__version__) < LooseVersion("2.5.0"):
+            if Version(dask.__version__) < Version("2.5.0"):
                 self.dataframe = dd.from_delayed(self.parts)
             else:
                 self.dataframe = dd.from_delayed(self.parts, verify_meta=self.verify)

--- a/intake/interface/__init__.py
+++ b/intake/interface/__init__.py
@@ -4,23 +4,23 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 gl = globals()
 
 
 def do_import():
-    error = too_old = False
     try:
         import panel as pn
-        too_old = LooseVersion(pn.__version__) < LooseVersion("0.9.5")
-    except ImportError as e:
-        error = e
+        import hvplot
+        error = (Version(pn.__version__) < Version("0.9.5")
+                   or Version(hvplot.__version__) < Version("0.8.1"))
+    except ImportError:
+        error = True
 
-    if too_old or error:
-        raise RuntimeError("Please install panel to use the GUI `conda "
-                           "install -c conda-forge panel>=0.8.0`. Import "
-                           "failed with error: %s" % error)
+    if error:
+        raise RuntimeError("Please install panel and hvplot to use the GUI\n"
+                           "`conda install -c conda-forge 'panel>=0.9.5' 'hvplot>=0.8.1'`")
 
     from .gui import GUI
     css = """

--- a/intake/interface/conftest.py
+++ b/intake/interface/conftest.py
@@ -8,6 +8,7 @@
 import os
 import pytest
 import intake
+import shutil
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -36,6 +37,13 @@ def cat1(cat1_url):
 def cat2(cat2_url):
     return intake.open_catalog(cat2_url)
 
+
+@pytest.fixture
+def copycat2(cat2_url, tmp_path):
+    parent_dir = os.path.dirname(cat2_url)
+    shutil.copytree(parent_dir, tmp_path / 'catalogs')
+    shutil.copytree(os.path.join(os.path.dirname(parent_dir), 'data'), tmp_path / 'data')
+    return intake.open_catalog(tmp_path / 'catalogs' / 'catalog2.yaml')
 
 @pytest.fixture
 def parent_cat(parent_cat_url):

--- a/intake/interface/source/defined_plots.py
+++ b/intake/interface/source/defined_plots.py
@@ -104,12 +104,14 @@ class Plots(BaseView):
             self.interact_cancel,
             self.interact_save,
         )
-        self.children = pn.Column(
-            self.row_select_plots,
-            self.row_dialog_buttons,
-            self.alert,
-            self.out,
-        )
+        self.children = [
+            pn.Column(
+                self.row_select_plots,
+                self.row_dialog_buttons,
+                pn.Row(self.alert),
+                self.out,
+            )
+        ]
         # Set initial visibility
         self.row_select_plots[-1].visible = False  # edit_options dropdown
         self.row_dialog_buttons.visible = False

--- a/intake/interface/source/gui.py
+++ b/intake/interface/source/gui.py
@@ -69,6 +69,7 @@ class SourceGUI(Base):
         self.description.source = self.sources
 
         self.plot = Plots(source=self.source_instance,
+                          edit_callback=self.on_plot_edited,
                           visible=self.plot_widget.value,
                           visible_callback=partial(
                           setattr, self.plot_widget, 'value'))
@@ -153,6 +154,10 @@ class SourceGUI(Base):
             self.description.panel.append(self.pars_editor.panel)
         else:
             self.description.panel.remove(self.pars_editor.panel)
+
+    def on_plot_edited(self):
+        # Manually triggered from plot widget when plot is saved
+        self.description.source = self.sources
 
     @property
     def sources(self):

--- a/intake/interface/source/gui.py
+++ b/intake/interface/source/gui.py
@@ -69,7 +69,6 @@ class SourceGUI(Base):
         self.description.source = self.sources
 
         self.plot = Plots(source=self.source_instance,
-                          edit_callback=self.on_plot_edited,
                           visible=self.plot_widget.value,
                           visible_callback=partial(
                           setattr, self.plot_widget, 'value'))
@@ -81,6 +80,7 @@ class SourceGUI(Base):
             self.plot_widget.param.watch(self.on_click_plot_widget, 'value'),
             self.pars_widget.param.watch(self.on_click_pars_widget, 'value'),
             self.select.widget.link(self.description, value='source'),
+            self.plot.watch(self.on_plot_edited)
         ]
 
     def setup(self):
@@ -155,8 +155,8 @@ class SourceGUI(Base):
         else:
             self.description.panel.remove(self.pars_editor.panel)
 
-    def on_plot_edited(self):
-        # Manually triggered from plot widget when plot is saved
+    def on_plot_edited(self, event):
+        # Redraw source YAML
         self.description.source = self.sources
 
     @property

--- a/intake/interface/source/gui.py
+++ b/intake/interface/source/gui.py
@@ -80,8 +80,8 @@ class SourceGUI(Base):
             self.plot_widget.param.watch(self.on_click_plot_widget, 'value'),
             self.pars_widget.param.watch(self.on_click_pars_widget, 'value'),
             self.select.widget.link(self.description, value='source'),
-            self.plot.watch(self.on_plot_edited)
         ]
+        self.plot.watch(self.on_plot_edited)
 
     def setup(self):
         self._setup_watchers()

--- a/intake/interface/source/tests/test_gui.py
+++ b/intake/interface/source/tests/test_gui.py
@@ -4,10 +4,10 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
-from distutils.version import LooseVersion
+from packaging.version import Version
 import pytest
 pn = pytest.importorskip('panel')
-too_old = LooseVersion(pn.__version__) < LooseVersion("0.9.5")
+too_old = Version(pn.__version__) < Version("0.9.5")
 
 
 @pytest.mark.skipif(too_old, reason="Use with latest panel")

--- a/intake/interface/source/tests/test_source_view.py
+++ b/intake/interface/source/tests/test_source_view.py
@@ -57,16 +57,15 @@ def test_description_clears_if_visible_is_set_to_false(description):
 def assert_is_empty(plots, visible=True):
     assert plots.source is None
     assert plots.has_plots is False
-    assert plots.instructions_contents == '*No predefined plots found - declare these in the catalog*'
     assert plots.options == []
     assert plots.selected is None
     if visible:
-        assert plots.instructions.object == plots.instructions_contents
         assert plots.pane.object is None
-        assert len(plots.children) == 2
+        assert plots.custom.name == 'Create'
+        assert len(plots.children) == 3
         assert isinstance(plots.children[-1][0][0], pn.pane.HoloViews)
         assert plots.panel.objects == plots.children
-        assert len(plots.watchers) == 2
+        assert len(plots.watchers) == 6
     else:
         assert not plots.selected
         assert not plots.watchers
@@ -75,17 +74,17 @@ def assert_is_empty(plots, visible=True):
 
 def assert_plotting_source2_0_line(plots, visible=True, desc=False):
     assert plots.has_plots is True
-    assert plots.instructions_contents == '**Select from the predefined plots:**'
     assert plots.options == ["None", 'line_example', 'violin_example']
     if visible:
         assert plots.selected == 'None'
         plots.selected = 'line_example'
-        assert plots.instructions.object == plots.instructions_contents
+        assert plots.custom.name == 'Edit'
+        assert plots.edit_options.visible
         assert plots.pane.object is not None
-        assert len(plots.children) == 2
+        assert len(plots.children) == 3
         assert isinstance(plots.children[-1][0][0], pn.pane.HoloViews)
         assert plots.panel.objects == plots.children
-        assert len(plots.watchers) == 2
+        assert len(plots.watchers) == 6
     else:
         assert not plots.selected
         assert not plots.watchers

--- a/intake/interface/source/tests/test_source_view.py
+++ b/intake/interface/source/tests/test_source_view.py
@@ -62,8 +62,8 @@ def assert_is_empty(plots, visible=True):
     if visible:
         assert plots.pane.object is None
         assert plots.custom.name == 'Create'
-        assert len(plots.children) == 3
-        assert isinstance(plots.children[-1][0][0], pn.pane.HoloViews)
+        assert len(plots.children[0]) == 4
+        assert isinstance(plots.children[0][-1][0][0], pn.pane.HoloViews)
         assert plots.panel.objects == plots.children
         assert len(plots.watchers) == 6
     else:
@@ -81,8 +81,8 @@ def assert_plotting_source2_0_line(plots, visible=True, desc=False):
         assert plots.custom.name == 'Edit'
         assert plots.edit_options.visible
         assert plots.pane.object is not None
-        assert len(plots.children) == 3
-        assert isinstance(plots.children[-1][0][0], pn.pane.HoloViews)
+        assert len(plots.children[0]) == 4
+        assert isinstance(plots.children[0][-1][0][0], pn.pane.HoloViews)
         assert plots.panel.objects == plots.children
         assert len(plots.watchers) == 6
     else:

--- a/intake/interface/tests/test_gui.py
+++ b/intake/interface/tests/test_gui.py
@@ -4,6 +4,7 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 #-----------------------------------------------------------------------------
+import yaml
 import pytest
 pn = pytest.importorskip('panel')
 
@@ -120,6 +121,145 @@ def test_gui_close_and_open_source(gui, cat2, sources2):
     assert gui.source.description.visible is True
     assert gui.source.plot.visible is False
     assert gui.source.sources == [sources2[0]]
+
+
+def test_gui_clone_plot(gui, copycat2, sources2):
+    pytest.importorskip('hvplot')
+
+    gui.source.select.cats = [copycat2]
+    gui.source.plot_widget.value = True
+    gui.source.plot.select.value = 'line_example'
+    assert gui.source.plot.edit_options.visible is True
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    gui.source.plot.edit_options.value = '  Clone'
+    assert gui.source.plot.row_dialog_buttons.visible is True
+    assert gui.source.plot.row_select_plots.visible is False
+    assert gui.source.plot.interact_label.object == 'Clone "**line_example**" as '
+    assert gui.source.plot.interact_name.value == ''
+    assert gui.source.plot.interact_save.disabled is True
+    assert gui.source.plot.interact_save.name == 'Clone'
+    # Set to invalid name (already used)
+    gui.source.plot.interact_name.value = 'violin_example'
+    gui.source.plot.interact_name.value_input = 'violin_example'
+    assert gui.source.plot.interact_save.disabled is True
+    assert gui.source.plot.alert.visible is True
+    assert gui.source.plot.alert.object == 'Name "violin_example" already exists'
+    # Set to valid name
+    gui.source.plot.interact_name.value = 'clone_example'
+    gui.source.plot.interact_name.value_input = 'clone_example'
+    assert gui.source.plot.interact_save.disabled is False
+    assert gui.source.plot.alert.visible is False
+    # Click the Clone button
+    gui.source.plot.interact_save.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.row_select_plots.visible is True
+    assert gui.source.plot.select.value == 'clone_example'
+    # Verify written to disk
+    with open(copycat2.path) as f:
+        d = yaml.safe_load(f)
+        assert 'clone_example' in d['sources']['us_crime']['metadata']['plots']
+        assert 'line_example' in d['sources']['us_crime']['metadata']['plots']
+
+
+def test_gui_rename_plot(gui, copycat2, sources2):
+    pytest.importorskip('hvplot')
+
+    gui.source.select.cats = [copycat2]
+    gui.source.plot_widget.value = True
+    gui.source.plot.select.value = 'line_example'
+    assert gui.source.plot.edit_options.visible is True
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    gui.source.plot.edit_options.value = '  Rename'
+    assert gui.source.plot.row_dialog_buttons.visible is True
+    assert gui.source.plot.row_select_plots.visible is False
+    assert gui.source.plot.interact_label.object == 'Rename "**line_example**" to '
+    assert gui.source.plot.interact_name.value == ''
+    assert gui.source.plot.interact_save.disabled is True
+    assert gui.source.plot.interact_save.name == 'Rename'
+    # Set to valid name
+    gui.source.plot.interact_name.value = 'rename_example'
+    gui.source.plot.interact_name.value_input = 'rename_example'
+    assert gui.source.plot.interact_save.disabled is False
+    assert gui.source.plot.alert.visible is False
+    # Click the Rename button
+    gui.source.plot.interact_save.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.row_select_plots.visible is True
+    assert gui.source.plot.select.value == 'rename_example'
+    # Verify written to disk
+    with open(copycat2.path) as f:
+        d = yaml.safe_load(f)
+        assert 'rename_example' in d['sources']['us_crime']['metadata']['plots']
+        assert 'line_example' not in d['sources']['us_crime']['metadata']['plots']
+
+
+def test_gui_delete_plot(gui, copycat2, sources2):
+    pytest.importorskip('hvplot')
+
+    gui.source.select.cats = [copycat2]
+    gui.source.plot_widget.value = True
+    gui.source.plot.select.value = 'line_example'
+    assert gui.source.plot.edit_options.visible is True
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    gui.source.plot.edit_options.value = '  Delete'
+    assert gui.source.plot.row_dialog_buttons.visible is True
+    assert gui.source.plot.row_select_plots.visible is False
+    assert gui.source.plot.interact_label.object == 'Really delete "**line_example**" ?'
+    assert gui.source.plot.interact_save.disabled is False
+    assert gui.source.plot.interact_save.name == 'Delete'
+    # Click the Delete button
+    gui.source.plot.interact_save.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.row_select_plots.visible is True
+    assert gui.source.plot.select.value == 'None'
+    # Verify written to disk
+    with open(copycat2.path) as f:
+        d = yaml.safe_load(f)
+        assert 'line_example' not in d['sources']['us_crime']['metadata']['plots']
+
+
+def test_gui_edit_plot(gui, copycat2, sources2):
+    pytest.importorskip('hvplot')
+
+    gui.source.select.cats = [copycat2]
+    gui.source.plot_widget.value = True
+    gui.source.plot.select.value = 'line_example'
+    assert gui.source.plot.edit_options.visible is True
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.custom.name == 'Edit'
+    gui.source.plot.custom.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is True
+    assert gui.source.plot.row_select_plots.visible is False
+    assert gui.source.plot.interact_label.object == 'Editing "**line_example**"'
+    assert gui.source.plot.interact_save.disabled is False
+    assert gui.source.plot.interact_save.name == 'Save'
+    # Click the Save button
+    gui.source.plot.interact_save.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.row_select_plots.visible is True
+    assert gui.source.plot.select.value == 'line_example'
+
+
+def test_gui_create_plot(gui, copycat2, sources2):
+    pytest.importorskip('hvplot')
+
+    gui.source.select.cats = [copycat2]
+    gui.source.plot_widget.value = True
+    gui.source.plot.select.value = 'None'
+    assert gui.source.plot.edit_options.visible is False
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.custom.name == 'Create'
+    gui.source.plot.custom.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is True
+    assert gui.source.plot.row_select_plots.visible is False
+    assert gui.source.plot.interact_label.object == 'Name '
+    assert gui.source.plot.interact_save.disabled is True
+    assert gui.source.plot.interact_save.name == 'Save'
+    # Click the Cancel button
+    gui.source.plot.interact_cancel.clicks += 1
+    assert gui.source.plot.row_dialog_buttons.visible is False
+    assert gui.source.plot.row_select_plots.visible is True
+    assert gui.source.plot.select.value == 'None'
 
 
 def test_gui_init_empty():

--- a/intake/interface/tests/test_gui.py
+++ b/intake/interface/tests/test_gui.py
@@ -58,8 +58,8 @@ def test_gui_open_plot_panel(gui, cat1, cat2, sources1, sources2):
     pytest.importorskip('hvplot')
     gui.source.plot_widget.value = True
     assert gui.source.plot.visible is True
-    assert len(gui.source.plot.watchers) == 2
-    assert len(gui.source.plot.panel.objects) == 2
+    assert len(gui.source.plot.watchers) == 6
+    assert len(gui.source.plot.panel.objects) == 3
     assert gui.source.plot.source.entry == sources1[0]
 
     gui.source.select.cats = [cat2]
@@ -68,8 +68,8 @@ def test_gui_open_plot_panel(gui, cat1, cat2, sources1, sources2):
     assert not gui.source.plot.watchers
 
     gui.source.plot_widget.value = True
-    assert len(gui.source.plot.watchers) == 2
-    assert len(gui.source.plot.panel.objects) == 2
+    assert len(gui.source.plot.watchers) == 6
+    assert len(gui.source.plot.panel.objects) == 3
 
 
 def test_gui_open_search_panel(gui, cat1, cat2, sources1, sources2):

--- a/intake/interface/tests/test_gui.py
+++ b/intake/interface/tests/test_gui.py
@@ -59,7 +59,7 @@ def test_gui_open_plot_panel(gui, cat1, cat2, sources1, sources2):
     gui.source.plot_widget.value = True
     assert gui.source.plot.visible is True
     assert len(gui.source.plot.watchers) == 6
-    assert len(gui.source.plot.panel.objects) == 3
+    assert len(gui.source.plot.panel.objects[0]) == 4
     assert gui.source.plot.source.entry == sources1[0]
 
     gui.source.select.cats = [cat2]
@@ -69,7 +69,7 @@ def test_gui_open_plot_panel(gui, cat1, cat2, sources1, sources2):
 
     gui.source.plot_widget.value = True
     assert len(gui.source.plot.watchers) == 6
-    assert len(gui.source.plot.panel.objects) == 3
+    assert len(gui.source.plot.panel.objects[0]) == 4
 
 
 def test_gui_open_search_panel(gui, cat1, cat2, sources1, sources2):


### PR DESCRIPTION
Create, rename, edit, delete plots -- all from the GUI.

If the catalog is a YAMLFileCatalog, changes will be saved.

Also, the default plot creation library for dataframes is now hvplot.explorer rather than dfviz.

## Screenshots of new functionality

### No plot selected -- changed "Customize" to "Create"
![No plot selected](https://user-images.githubusercontent.com/2807270/201767018-90fad420-eae0-4cd2-892b-a82d3936c675.png)

### Creation uses hvplot.explorer
![Create new plot](https://user-images.githubusercontent.com/2807270/201767040-b1debc4a-5024-4892-bf39-f81762573390.png)

### When viewing a plot, new options are available
![Edit existing plot](https://user-images.githubusercontent.com/2807270/201767047-ce879c47-5351-441d-a276-5b5fa00e49f9.png)

### Dialog for renaming a plot
![Rename plot](https://user-images.githubusercontent.com/2807270/201767057-7fd5da9a-7614-4332-b9b4-1918a90174ee.png)
