### PR TITLE
Docs: update how list of plugins is generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/source/plugin-list.html
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,11 @@ help:
 
 .PHONY: help Makefile
 
+# Run custom script to build HTML table of plugins
+html: Makefile
+	python plugins.py
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - sphinx_rtd_theme
   - numpydoc
   - entrypoints
+  - aiohttp

--- a/docs/plugins.py
+++ b/docs/plugins.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import yaml
+
+
+def format_package_links(package_name, repo_link):
+    if "http" not in repo_link:
+        repo_link = f"https://github.com/{repo_link}/"
+
+    return f'<a href="{repo_link}">{package_name}</a>'
+
+
+def generate_plugin_table():
+    plugins = yaml.safe_load(open("plugins.yaml", "rb"))
+    plugin_df = pd.DataFrame(plugins).fillna("")
+    plugin_df["Package Name"] = plugin_df.apply(lambda x: format_package_links(x["name"], x["repo"]), axis=1)
+    plugin_df = plugin_df.rename(columns={"description": "Description", "drivers": "Drivers"})
+
+    plugin_df.to_html(
+        "source/plugin-list.html",
+        escape=False,
+        justify="left",
+        index=False,
+        columns=["Package Name", "Description", "Drivers"],
+    )
+
+
+if __name__ == "__main__":
+    print("Generating custom plugin table... ", end="")
+    generate_plugin_table()
+    print("done")

--- a/docs/plugins.py
+++ b/docs/plugins.py
@@ -1,26 +1,106 @@
+import asyncio
+
+import aiohttp
 import pandas as pd
 import yaml
 
 
 def format_package_links(package_name, repo_link):
-    if "http" not in repo_link:
-        repo_link = f"https://github.com/{repo_link}/"
-
     return f'<a href="{repo_link}">{package_name}</a>'
+
+
+def format_repo_link(repo_link):
+    if "http" not in repo_link:
+        return f"https://github.com/{repo_link}/"
+    return repo_link
+
+
+def format_badge_html(badge, link):
+    return f'<a href="{link}"><img src="{badge}"/></a>'
+
+
+async def check_ok(client, url):
+    async with client.get(url) as r:
+        if "anaconda.org" in url:
+            body = await r.text()
+            if "requires authentication" in body:
+                return False
+        return r.ok
+
+
+async def check_all_ok(urls):
+    async with aiohttp.client.ClientSession() as c:
+        coroutines = [check_ok(c, url) for url in urls]
+        return await asyncio.gather(*coroutines)
 
 
 def generate_plugin_table():
     plugins = yaml.safe_load(open("plugins.yaml", "rb"))
-    plugin_df = pd.DataFrame(plugins).fillna("")
-    plugin_df["Package Name"] = plugin_df.apply(lambda x: format_package_links(x["name"], x["repo"]), axis=1)
+    plugin_df = pd.DataFrame(plugins)
     plugin_df = plugin_df.rename(columns={"description": "Description", "drivers": "Drivers"})
+
+    plugin_df["short_name"] = plugin_df["name"].apply(lambda x: x.split("/")[-1])
+    plugin_df["repo_links"] = plugin_df["repo"].apply(format_repo_link)
+    plugin_df["conda_package"] = plugin_df["conda_package"].fillna(plugin_df["short_name"])
+
+    # CI badges
+    plugin_df["ci_badges"] = plugin_df["repo_links"].apply(lambda x: f"{x}/workflows/CI/badge.svg")
+    plugin_df["ci_links"] = plugin_df["repo_links"].apply(lambda x: f"{x}/actions")
+    ci_badges_ok = asyncio.run(check_all_ok(plugin_df["ci_badges"]))
+
+    # Docs badges
+    plugin_df["docs_badges"] = plugin_df["short_name"].apply(lambda x: f"https://readthedocs.org/projects/{x}/badge/?version=latest")
+    plugin_df["docs_links"] = plugin_df["short_name"].apply(lambda x: f"https://{x}.readthedocs.io/en/latest/?badge=latest")
+    docs_badges_ok = asyncio.run(check_all_ok(plugin_df["docs_links"]))
+
+    # PyPi badges
+    plugin_df["pypi_badges"] = plugin_df["short_name"].apply(lambda x: f"https://img.shields.io/pypi/v/{x}.svg?maxAge=3600")
+    plugin_df["pypi_links"] = plugin_df["short_name"].apply(lambda x: f"https://pypi.org/project/{x}")
+    pypi_badges_ok = asyncio.run(check_all_ok(plugin_df["pypi_links"]))
+
+    # Conda badges
+    plugin_df["conda_badges"] = plugin_df[["conda_channel", "conda_package"]].apply(
+        lambda x: f"https://img.shields.io/conda/vn/{x[0]}/{x[1]}.svg?colorB=4488ff&label={x[0]}&style=flat", axis=1
+    )
+    plugin_df["conda_links"] = plugin_df[["conda_channel", "conda_package"]].apply(lambda x: f"https://anaconda.org/{x[0]}/{x[1]}", axis=1)
+    conda_badges_ok = asyncio.run(check_all_ok(plugin_df["conda_links"]))
+
+    # Conda defaults badges
+    plugin_df["conda_defaults_links"] = plugin_df["conda_package"].apply(lambda x: f"https://anaconda.org/anaconda/{x}")
+    plugin_df["conda_defaults_badges"] = plugin_df["conda_package"].apply(
+        lambda x: f"https://img.shields.io/conda/vn/anaconda/{x}.svg?colorB=4488ff&label=defaults&style=flat"
+    )
+    conda_defaults_badges_ok = asyncio.run(check_all_ok(plugin_df["conda_defaults_links"]))
+
+    # Conda forge badges
+    plugin_df["conda_forge_links"] = plugin_df["conda_package"].apply(lambda x: f"https://anaconda.org/conda-forge/{x}")
+    plugin_df["conda_forge_badges"] = plugin_df["conda_package"].apply(lambda x: f"https://img.shields.io/conda/vn/conda-forge/{x}.svg?colorB=4488ff&style=flat")
+    conda_forge_badges_ok = asyncio.run(check_all_ok(plugin_df["conda_forge_links"]))
+
+    plugin_df["Package Name"] = plugin_df[["name", "repo_links"]].apply(lambda x: format_package_links(*x), axis=1)
+    plugin_df["CI"] = plugin_df[["ci_badges", "ci_links"]][ci_badges_ok].apply(lambda x: format_badge_html(*x), axis=1)
+    plugin_df["Docs"] = plugin_df[["docs_badges", "docs_links"]][docs_badges_ok].apply(lambda x: format_badge_html(*x), axis=1)
+    plugin_df["PyPi"] = plugin_df[["pypi_badges", "pypi_links"]][pypi_badges_ok].apply(lambda x: format_badge_html(*x), axis=1)
+    plugin_df["conda"] = plugin_df[["conda_badges", "conda_links"]][conda_badges_ok].apply(lambda x: format_badge_html(*x), axis=1)
+    plugin_df["conda_forge"] = plugin_df[["conda_forge_badges", "conda_forge_links"]][conda_forge_badges_ok].apply(lambda x: format_badge_html(*x), axis=1)
+    plugin_df["conda_defaults"] = plugin_df[["conda_defaults_badges", "conda_defaults_links"]][conda_defaults_badges_ok].apply(
+        lambda x: format_badge_html(*x), axis=1
+    )
+
+    plugin_df = plugin_df.fillna("")
+
+    # Concat conda badges
+    plugin_df["Conda"] = plugin_df["conda"] + plugin_df["conda_forge"] + plugin_df["conda_defaults"]
 
     plugin_df.to_html(
         "source/plugin-list.html",
         escape=False,
         justify="left",
         index=False,
-        columns=["Package Name", "Description", "Drivers"],
+        border=0,
+        classes="table_wrapper",
+        columns=["Package Name", "Description", "Drivers", "CI", "Docs", "PyPi", "Conda"],
+        col_space=["auto", "auto", "auto", "90px", "90px", "90px", "90px"],
     )
 
 

--- a/docs/plugins.yaml
+++ b/docs/plugins.yaml
@@ -7,6 +7,7 @@
   repo: intake/intake-astro
   description: Table and array loading of FITS astronomical data
   drivers: fits_array, fits_table
+  conda_channel: intake
 
 - name: intake-accumulo
   repo: intake/intake-accumulo
@@ -36,6 +37,8 @@
   repo: informatics-lab/intake-dynamodb>
   description: Link to Amazon DynamoDB
   drivers: dynamodb
+  conda_channel: informaticslab
+  conda_package: intake_dynamodb
 
 - name: intake-elasticsearch
   repo: intake/intake-elasticsearch
@@ -50,6 +53,7 @@
   repo: informatics-lab/intake_geopandas
   description: Load from ESRI Shape Files, GeoJSON, and geospatial databases with geopandas
   drivers: geojson, postgis, shapefile, spatialite, regionmask
+  conda_channel: informaticslab
 
 - name: intake-google-analytics
   repo: intake/intake-google-analytics
@@ -60,11 +64,14 @@
   repo: intake/intake-hbase
   description: Apache HBase database
   drivers: hbase
+  conda_channel: intake
 
 - name: intake-iris
   repo: informatics-lab/intake-iris
   description: Load netCDF and GRIB files with IRIS
   drivers: grib, netcdf
+  conda_channel: informaticslab
+  conda_package: intake_iris
 
 - name: intake-metabase
   repo: continuumio/intake-metabase
@@ -75,6 +82,7 @@
   repo: intake/intake-mongo
   description: MongoDB noSQL query
   drivers: mongo
+  conda_channel: intake
 
 - name: intake-nested-yaml-catalog
   repo: zillow/intake-nested-yaml-catalog
@@ -85,16 +93,19 @@
   repo: intake/intake-netflow
   description: Netflow packet format
   drivers: netflow
+  conda_channel: intake
 
 - name: intake-notebook
   repo: informatics-lab/intake-notebook
   description: Experimental plugin to access parameterised notebooks through intake and executed via papermill
   drivers: ipynb
+  conda_channel: informaticslab
 
 - name: intake-odbc
   repo: intake/intake-odbc
   description: ODBC database
   drivers: odbc
+  conda_channel: intake
 
 - name: intake-parquet
   repo: intake/intake-parquet
@@ -115,10 +126,13 @@
   repo: intake/intake-postgres
   description: PostgreSQL database
   drivers: postgres
+  conda_channel: intake
 
 - name: intake-s3-manifests
   repo: informatics-lab/intake-s3-manifests
   drivers: s3_manifest
+  conda_channel: informaticslab
+  conda_package: intake_s3_manifests
 
 - name: intake-salesforce
   repo: sophiamyang/intake-salesforce
@@ -134,6 +148,7 @@
   repo: intake/intake-solr
   description: Apache Solr search platform
   drivers: solr
+  conda_channel: intake
 
 - name: intake-stac
   repo: intake/intake-stac
@@ -163,6 +178,7 @@
   repo: intake/intake-splunk
   description: Splunk machine data query
   drivers: splunk
+  conda_channel: intake
 
 - name: intake-streamz
   repo: intake/intake-streamz

--- a/docs/plugins.yaml
+++ b/docs/plugins.yaml
@@ -1,0 +1,180 @@
+- name: intake
+  repo: intake/intake
+  description: Builtin to Intake
+  drivers: catalog, csv, intake_remote, ndzarr, numpy, textfiles, yaml_file_cat, yaml_files_cat, zarr_cat, json, jsonl
+
+- name: intake-astro
+  repo: intake/intake-astro
+  description: Table and array loading of FITS astronomical data
+  drivers: fits_array, fits_table
+
+- name: intake-accumulo
+  repo: intake/intake-accumulo
+  description: Apache Accumulo clustered data storage
+  drivers: accumulo
+
+- name: intake-avro
+  repo: intake/intake-avro
+  description: Apache Avro data serialization format
+  drivers: avro_table, avro_sequence
+
+- name: intake-bluesky
+  repo: nsls-ii/intake-bluesky
+  description: Search and retrieve data in the <a href="https://nsls-ii.github.io/bluesky">bluesky</a> data model
+
+- name: intake-dcat
+  repo: CityOfLosAngeles/intake-dcat
+  description: Browse and load data from <a href="https://www.w3.org/TR/vocab-dcat">DCAT</a> catalogs
+  drivers: dcat
+
+- name: intake-dremio
+  repo: intake/intake-dremio
+  description: Scan tables and send SQL queries to a <a href="https://docs.dremio.com/"> Dremio </a> server
+  drivers: dremio
+
+- name: intake-dynamodb
+  repo: informatics-lab/intake-dynamodb>
+  description: Link to Amazon DynamoDB
+  drivers: dynamodb
+
+- name: intake-elasticsearch
+  repo: intake/intake-elasticsearch
+  description: Elasticsearch search and analytics engine
+  drivers: elasticsearch_seq, elasticsearch_table
+
+- name: intake-esm
+  repo: NCAR/intake-esm
+  description: Plugin for building and loading intake catalogs for earth system data sets holdings, such as <a href="https://cmip.llnl.gov/">CMIP</a> (Coupled Model Intercomparison Project) and CESM Large Ensemble datasets
+
+- name: intake-geopandas
+  repo: informatics-lab/intake_geopandas
+  description: Load from ESRI Shape Files, GeoJSON, and geospatial databases with geopandas
+  drivers: geojson, postgis, shapefile, spatialite, regionmask
+
+- name: intake-google-analytics
+  repo: intake/intake-google-analytics
+  description: Run Google Analytics queries and load data as a DataFrame
+  drivers: google_analytics_query
+
+- name: intake-hbase
+  repo: intake/intake-hbase
+  description: Apache HBase database
+  drivers: hbase
+
+- name: intake-iris
+  repo: informatics-lab/intake-iris
+  description: Load netCDF and GRIB files with IRIS
+  drivers: grib, netcdf
+
+- name: intake-metabase
+  repo: continuumio/intake-metabase
+  description: Generate catalogs and load tables as DataFrames from Metabase
+  drivers: metabase_catalog, metabase_table
+
+- name: intake-mongo
+  repo: intake/intake-mongo
+  description: MongoDB noSQL query
+  drivers: mongo
+
+- name: intake-nested-yaml-catalog
+  repo: zillow/intake-nested-yaml-catalog
+  description: Plugin supporting a single YAML hierarchical catalog to organize datasets and avoid a data swamp
+  drivers: nested_yaml_cat
+
+- name: intake-netflow
+  repo: intake/intake-netflow
+  description: Netflow packet format
+  drivers: netflow
+
+- name: intake-notebook
+  repo: informatics-lab/intake-notebook
+  description: Experimental plugin to access parameterised notebooks through intake and executed via papermill
+  drivers: ipynb
+
+- name: intake-odbc
+  repo: intake/intake-odbc
+  description: ODBC database
+  drivers: odbc
+
+- name: intake-parquet
+  repo: intake/intake-parquet
+  description: Apache Parquet file format
+  drivers: parquet
+
+- name: intake-pattern-catalog
+  repo: https://bitbucket.org/dtnse/intake_pattern_catalog
+  description: Plugin for specifying a file-path pattern which can represent a number of different entries
+  drivers: pattern_cat
+
+- name: intake-pcap
+  repo: intake/intake-pcap
+  description: PCAP network packet format
+  drivers: pcap
+
+- name: intake-postgres
+  repo: intake/intake-postgres
+  description: PostgreSQL database
+  drivers: postgres
+
+- name: intake-s3-manifests
+  repo: informatics-lab/intake-s3-manifests
+  drivers: s3_manifest
+
+- name: intake-salesforce
+  repo: sophiamyang/intake-salesforce
+  description: Generate catalogs and load tables as DataFrames from Salesforce
+  drivers: salesforce_catalog, salesforce_table
+
+- name: intake-sklearn
+  repo: AlbertDeFusco/intake-sklearn
+  description: Load scikit-learn models from Pickle files
+  drivers: sklearn
+
+- name: intake-solr
+  repo: intake/intake-solr
+  description: Apache Solr search platform
+  drivers: solr
+
+- name: intake-stac
+  repo: intake/intake-stac
+  description: Intake Driver for <a href="https://stacspec.org/">SpatioTemporal Asset Catalogs (STAC)</a>
+
+- name: intake-stripe
+  repo: sophiamyang/intake-stripe
+  description: Generate catalogs and load tables as DataFrames from Stripe
+  drivers: stripe_catalog, stripe_table
+
+- name: intake-spark
+  repo: intake/intake-spark
+  description: Data processed by Apache Spark
+  drivers: spark_cat, spark_rdd, spark_dataframe
+
+- name: intake-sql
+  repo: intake/intake-sql
+  description: Generic SQL queries via SQLAlchemy
+  drivers: sql_cat, sql, sql_auto, sql_manual
+
+- name: intake-sqlite
+  repo: catalyst-cooperative/intake-sqlite
+  description: Local caching of remote SQLite DBs and queries via SQLAlchemy
+  drivers: sqlite_cat, sqlite, sqlite_auto, sqlite_manual
+
+- name: intake-splunk
+  repo: intake/intake-splunk
+  description: Splunk machine data query
+  drivers: splunk
+
+- name: intake-streamz
+  repo: intake/intake-streamz
+  description: Real-time event processing using Streamz
+  drivers: streamz
+
+- name: intake-thredds
+  repo: NCAR/intake-thredds
+  description: Intake interface to THREDDS data catalogs
+  drivers: thredds_cat, thredds_merged_source
+
+- name: intake-xarray
+  repo: intake/intake-xarray
+  description: Load netCDF, Zarr and other multi-dimensional data
+  drivers: xarray_image, netcdf, grib, opendap, rasterio, remote-xarray, zarr

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -5,3 +5,16 @@ div.prompt {
 div.logo-block img {
   display: none !important
 }
+
+.table_wrapper{
+  display: block;
+  overflow-x: auto;
+}
+
+.table_wrapper td, th {
+  padding: 2px;
+}
+
+.table_wrapper tr:nth-child(even) {
+  background: #E0E0E0;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,6 +114,9 @@ if not on_rtd:
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
+html_css_files = [
+    "css/custom.css",
+]
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/source/plugin-directory.rst
+++ b/docs/source/plugin-directory.rst
@@ -9,7 +9,7 @@ contains:
 .. raw:: html
    :file: plugin-list.html
 
-The status of these projects is available at `Status Dashboard <https://intake.github.io/status/>`_.
+
 
 Don't see your favorite format?  See :doc:`making-plugins` for how to create new plugins.
 

--- a/docs/source/plugin-directory.rst
+++ b/docs/source/plugin-directory.rst
@@ -4,48 +4,10 @@ Plugin Directory
 ================
 
 This is a list of known projects which install driver plugins for Intake, and the named drivers each
-contains in parentheses:
+contains:
 
-* builtin to Intake (``catalog``, ``csv``, ``intake_remote``, ``ndzarr``,
-  ``numpy``, ``textfiles``, ``yaml_file_cat``, ``yaml_files_cat``, ``zarr_cat``,
-  ``json``, ``jsonl``)
-* `intake-astro <https://github.com/intake/intake-astro>`_ Table and array loading of FITS astronomical data (``fits_array``, ``fits_table``)
-* `intake-accumulo <https://github.com/intake/intake-accumulo>`_ Apache Accumulo clustered data storage (``accumulo``)
-* `intake-avro <https://github.com/intake/intake-avro>`_: Apache Avro data serialization format (``avro_table``, ``avro_sequence``)
-* `intake-bluesky <https://nsls-ii.github.io/intake-bluesky/>`_: search and retrieve data in the `bluesky <https://nsls-ii.github.io/bluesky>`_ data model
-* `intake-dcat <https://github.com/CityOfLosAngeles/intake-dcat>`_ Browse and load data from `DCAT <https://www.w3.org/TR/vocab-dcat>`_ catalogs. (``dcat``)
-* `intake-dremio <https://github.com/intake/intake-dremio>`_: Scan tables and send SQL queries to a `Dremio <https://docs.dremio.com/>`_ server (``dremio``)
-* `intake-dynamodb <https://github.com/informatics-lab/intake-dynamodb>`_ link to Amazon DynamoDB (``dynamodb``)
-* `intake-elasticsearch <https://github.com/intake/intake-elasticsearch>`_: Elasticsearch search and analytics engine (``elasticsearch_seq``, ``elasticsearch_table``)
-* `intake-esm <https://github.com/NCAR/intake-esm>`_:  Plugin for building and loading intake catalogs for earth system data sets holdings, such as `CMIP <https://cmip.llnl.gov/>`_ (Coupled Model Intercomparison Project) and CESM Large Ensemble datasets.
-* `intake-geopandas <https://github.com/informatics-lab/intake_geopandas>`_: load from ESRI Shape Files, GeoJSON, and geospatial databases with geopandas (``geojson``, ``postgis``, ``shapefile``, ``spatialite``) and ``regionmask`` for opening shapefiles into `regionmask <https://github.com/mathause/regionmask/>`_.
-* `intake-google-analytics <https://github.com/intake/intake-google-analytics>`_: run Google Analytics queries and load data as a DataFrame (``google_analytics_query``)
-* `intake-hbase <https://github.com/intake/intake-hbase>`_: Apache HBase database (``hbase``)
-* `intake-iris <https://github.com/informatics-lab/intake-iris>`_ load netCDF and GRIB files with IRIS (``grib``, ``netcdf``)
-* `intake-metabase <https://github.com/continuumio/intake-metabase>`_: Generate catalogs and load tables as DataFrames from Metabase (``metabase_catalog``, ``metabase_table``)
-* `intake-mongo <https://github.com/intake/intake-mongo>`_: MongoDB noSQL query (``mongo``)
-* `intake-nested-yaml-catalog <https://github.com/zillow/intake-nested-yaml-catalog>`__: Plugin supporting a single YAML hierarchical catalog to organize datasets and avoid a data swamp. (``nested_yaml_cat``)
-* `intake-netflow <https://github.com/intake/intake-netflow>`_: Netflow packet format (``netflow``)
-* `intake-notebook <https://github.com/informatics-lab/intake-notebook>`_: Experimental plugin to access parameterised notebooks through intake and executed via papermill (``ipynb``)
-* `intake-odbc <https://github.com/intake/intake-odbc>`_: ODBC database (``odbc``)
-* `intake-parquet <https://github.com/intake/intake-parquet>`_: Apache Parquet file format (``parquet``)
-* `intake-pattern-catalog <https://bitbucket.org/dtnse/intake_pattern_catalog/>`_: Plugin for specifying a file-path pattern which can represent a number of different entries (``pattern_cat``)
-* `intake-pcap <https://github.com/intake/intake-pcap>`_: PCAP network packet format (``pcap``)
-* `intake-postgres <https://github.com/intake/intake-postgres>`_: PostgreSQL database (``postgres``)
-* `intake-s3-manifests <https://github.com/informatics-lab/intake-s3-manifests>`_ (``s3_manifest``)
-* `intake-salesforce <https://github.com/sophiamyang/intake-salesforce>`_: Generate catalogs and load tables as DataFrames from Salesforce (``salesforce_catalog``, ``salesforce_table``)
-* `intake-sklearn <https://github.com/AlbertDeFusco/intake-sklearn>`_: Load scikit-learn models from Pickle files (``sklearn``)
-* `intake-solr <https://github.com/intake/intake-solr>`_: Apache Solr search platform (``solr``)
-* `intake-stac <https://github.com/intake/intake-stac>`_: Intake Driver for `SpatioTemporal Asset Catalogs (STAC) <https://stacspec.org/>`_.
-* `intake-stripe <https://github.com/sophiamyang/intake-stripe>`_: Generate catalogs and load tables as DataFrames from Stripe (``stripe_catalog``, ``stripe_table``)
-* `intake-spark <https://github.com/intake/intake-spark>`_: data processed by Apache Spark (``spark_cat``, ``spark_rdd``, ``spark_dataframe``)
-* `intake-sql <https://github.com/intake/intake-sql>`_: Generic SQL queries via SQLAlchemy (``sql_cat``, ``sql``, ``sql_auto``, ``sql_manual``)
-* `intake-sqlite <https://github.com/catalyst-cooperative/intake-sqlite>`_: Local caching of remote SQLite DBs and queries via SQLAlchemy (``sqlite_cat``, ``sqlite``, ``sqlite_auto``, ``sqlite_manual``)
-* `intake-splunk <https://github.com/intake/intake-splunk>`_: Splunk machine data query (``splunk``)
-* `intake-streamz <https://github.com/intake/intake-streamz>`_: real-time event processing using Streamz (``streamz``)
-* `intake-thredds <https://github.com/NCAR/intake-thredds>`_: Intake interface to THREDDS data catalogs (``thredds_cat``, ``thredds_merged_source``)
-* `intake-xarray <https://github.com/intake/intake-xarray>`_: load netCDF, Zarr and other multi-dimensional data (``xarray_image``, ``netcdf``, ``grib``, ``opendap``, ``rasterio``, ``remote-xarray``, ``zarr``)
-
+.. raw:: html
+   :file: plugin-list.html
 
 The status of these projects is available at `Status Dashboard <https://intake.github.io/status/>`_.
 


### PR DESCRIPTION
Moved most of the functionality from https://github.com/intake/status to this repo. Now the list of plugins is displayed in a table with the badges displayed in the same row. Folks can add new entries by updating the YAML and badges will be automatically discovered.
<img width="749" alt="Screen Shot 2023-02-24 at 11 39 37 AM" src="https://user-images.githubusercontent.com/20345373/221275678-46ac2939-74b6-45af-9133-c5b2b0c946de.png">

Closes https://github.com/intake/status/issues/17