### PR TITLE
create GUI instance rather than CatalogGUI

### DIFF
--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -484,8 +484,9 @@ class Catalog(DataSource):
     @property
     def gui(self):
         if not hasattr(self, "_gui"):
-            from ..interface.gui import GUI
             from ..interface import output_notebook
+            from ..interface.gui import GUI
+
             output_notebook()
             self._gui = GUI(self)
         else:

--- a/intake/catalog/base.py
+++ b/intake/catalog/base.py
@@ -484,9 +484,10 @@ class Catalog(DataSource):
     @property
     def gui(self):
         if not hasattr(self, "_gui"):
-            from .gui import CatalogGUI
-
-            self._gui = CatalogGUI(cat=self, visible=True)
+            from ..interface.gui import GUI
+            from ..interface import output_notebook
+            output_notebook()
+            self._gui = GUI(self)
         else:
             self._gui.visible = True
         return self._gui


### PR DESCRIPTION
This addresses #714 . The CatalogGUI instance does not work well if there are nested catalogs. Here's an example catalog.yaml file

```yaml
name: my_local_catalog
sources:
    df:
      driver: csv
      args:
        urlpath: https://bit.ly/autompg-csv
    weather:
        driver: yaml_file_cat
        args:
            path: https://gist.githubusercontent.com/AlbertDeFusco/60a3d2031f89f1fed1d396bb367fe168/raw/401b29419608abd51985f45a81308bc3f4534410/weather.yaml
```

I've included a short screen capture to demonstrate what this change enables. You'll notice `df` in the list of sources in the root of the catalog and the nested `weather` catalog.

![ScreenFlow](https://user-images.githubusercontent.com/43654/222244063-4e83880c-c23e-4393-9354-e1bd12114ccb.gif)
