### PR TITLE
Use sys.executable when starting http server

### DIFF
--- a/intake/conftest.py
+++ b/intake/conftest.py
@@ -8,6 +8,7 @@
 import os
 import posixpath
 import subprocess
+import sys
 import tempfile
 import time
 
@@ -142,9 +143,9 @@ def intake_server(request):
 def http_server():
     port_as_str = str(pick_port())
     if PY2:
-        cmd = ["python", "-m", "SimpleHTTPServer", port_as_str]
+        cmd = [sys.executable, "-m", "SimpleHTTPServer", port_as_str]
     else:
-        cmd = ["python", "-m", "http.server", port_as_str]
+        cmd = [sys.executable, "-m", "http.server", port_as_str]
     p = subprocess.Popen(cmd, cwd=os.path.join(here, "catalog", "tests"))
     url = "http://localhost:{}/".format(port_as_str)
     timeout = 5


### PR DESCRIPTION
To avoid calling python directly, which may be Python 2 in some environments, use sys.executable, which returns the path of the current interpreter when starting the test http server.