### PR TITLE
Update missing driver error message

### DIFF
--- a/intake/tests/test_top_level.py
+++ b/intake/tests/test_top_level.py
@@ -97,6 +97,17 @@ def test_bad_open():
     assert intake.open_catalog() == intake.open_catalog(None)
 
 
+def test_bad_open_helptext():
+    with pytest.raises(ValueError) as val_err:
+        # unknown driver
+        intake.open_catalog("", driver="unknown")
+    assert "plugin directory" in str(val_err.value).lower()
+
+    with pytest.raises(AttributeError) as attr_err:
+        intake.open_not_a_real_plugin()
+    assert "plugin directory" in str(attr_err.value).lower()
+
+
 def test_output_notebook():
     pytest.importorskip("hvplot")
     intake.output_notebook()


### PR DESCRIPTION
Adds link to plugin directory if user tries to call `intake.open_*` or `intake.open_catalog(url, driver=...)` with an unregistered driver

Closes https://github.com/intake/intake/issues/730