### PR TITLE
Dedaskify CSV

### DIFF
--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -187,7 +187,7 @@ class TestServerV1Source(TestServerV1Base):
 
         # Cheat and look into internal state now
         source = self.server._cache.peek(source_id)
-        assert isinstance(source._pandas_dfs, list)
+        assert source._files is not None
 
         # now wait slightly over idle time, run periodic functions,
         # and check again
@@ -196,7 +196,7 @@ class TestServerV1Source(TestServerV1Base):
 
         # should be closed
         source = self.server._cache.peek(source_id)
-        assert source._pandas_dfs is None
+        assert source._files is None
 
         # wait a little longer
         time.sleep(0.1)

--- a/intake/cli/server/tests/test_server.py
+++ b/intake/cli/server/tests/test_server.py
@@ -187,7 +187,7 @@ class TestServerV1Source(TestServerV1Base):
 
         # Cheat and look into internal state now
         source = self.server._cache.peek(source_id)
-        assert source._dataframe is not None
+        assert isinstance(source._pandas_dfs, list)
 
         # now wait slightly over idle time, run periodic functions,
         # and check again
@@ -196,7 +196,7 @@ class TestServerV1Source(TestServerV1Base):
 
         # should be closed
         source = self.server._cache.peek(source_id)
-        assert source._dataframe is None
+        assert source._pandas_dfs is None
 
         # wait a little longer
         time.sleep(0.1)

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -150,16 +150,18 @@ class CSVSource(base.DataSource, base.PatternMixin):
             df_part = pd.read_csv(url_part, storage_options=self._storage_options, **self._csv_kwargs)
 
         else:
-            drop_path_column = "include_path_column" not in self._csv_kwargs
+            include_path_column = "include_path_column" in self._csv_kwargs
             path_column = self._path_column()
 
-            df_part = pd.read_csv(url_part, storage_options=self._storage_options, **self._csv_kwargs)
+            csv_kwargs = self._csv_kwargs
+            csv_kwargs.pop("include_path_column")
+            df_part = pd.read_csv(url_part, storage_options=self._storage_options, **csv_kwargs)
 
             # add the new columns to the dataframe
             self._set_pattern_columns(path_column)
 
-            if drop_path_column:
-                df_part = df_part.drop([path_column], axis=1)
+            if include_path_column:
+                df_part[path_column] = url_part
 
         self._pandas_dfs[i] = df_part
         return df_part

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -5,6 +5,8 @@
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
+from fsspec.core import get_fs_token_paths
+
 from . import base
 from .utils import reverse_formats, unique_string
 
@@ -121,8 +123,6 @@ class CSVSource(base.DataSource, base.PatternMixin):
         if self.pattern is None and not glob_in_path:
             self._files = urlpath
         else:
-            from fsspec.core import get_fs_token_paths
-
             self._files = get_fs_token_paths(urlpath)[2]
 
         return sorted(self._files)

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -146,7 +146,7 @@ class CSVSource(base.DataSource, base.PatternMixin):
         else:
             df = next(df for df in self._pandas_dfs if df is not None)
 
-        dtypes = dict(df.dtypes)
+        dtypes = {col: str(dtype) for col, dtype in df.dtypes.items()}
         return base.Schema(dtype=dtypes, shape=(None, len(dtypes)), npartitions=len(self._files), extra_metadata={})
 
     def _get_partition(self, i):
@@ -201,3 +201,4 @@ class CSVSource(base.DataSource, base.PatternMixin):
 
     def _close(self):
         self._dask_df = None
+        self._pandas_dfs = None

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -130,25 +130,19 @@ def test_read_chunked(sample1_datasource, data_filenames):
     assert expected_df.equals(df)
 
 
-def check_read_pattern_output(source):
-    da = source.to_dask()
-    assert da.num.cat.known is True
-    assert da.dup.cat.known is True
-
+def check_read_pattern_output(df, df_part):
     # check that first partition has correct num and dup; which file
     # it represents is not guaranteed
-    df0 = da.get_partition(0).compute()
-    if df0["name"][0].endswith("1"):
-        assert all(df0.num == 2)
-        assert all(df0.dup == 1)
-    elif df0["name"][0].endswith("2"):
-        assert all(df0.num == 2)
-        assert all(df0.dup == 2)
-    elif df0["name"][0].endswith("3"):
-        assert all(df0.num == 3)
-        assert all(df0.dup == 2)
+    if df_part["name"][0].endswith("1"):
+        assert all(df_part.num == 2)
+        assert all(df_part.dup == 1)
+    elif df_part["name"][0].endswith("2"):
+        assert all(df_part.num == 2)
+        assert all(df_part.dup == 2)
+    elif df_part["name"][0].endswith("3"):
+        assert all(df_part.num == 3)
+        assert all(df_part.dup == 2)
 
-    df = source.read()
     assert len(df.columns) == 5
     assert "num" in df
     assert "dup" in df
@@ -169,28 +163,35 @@ def check_read_pattern_output(source):
     assert all(file_3.num == 3)
     assert all(file_3.dup == 2)
 
-    return da
 
-
-def test_read_pattern(sample_pattern_datasource):
+def test_read_pattern_dask(sample_pattern_datasource):
     da = sample_pattern_datasource.to_dask()
     assert set(da.num.cat.categories) == {2, 3}
     assert set(da.dup.cat.categories) == {1, 2}
-    check_read_pattern_output(sample_pattern_datasource)
+    check_read_pattern_output(da.compute(), da.get_partition(0).compute())
+
+
+def test_read_pattern_pandas(sample_pattern_datasource):
+    sample_pattern_datasource._dask_df = None
+    df = sample_pattern_datasource.read()
+    assert set(df.num.cat.categories) == {2, 3}
+    assert set(df.dup.cat.categories) == {1, 2}
+    df_part = sample_pattern_datasource._get_partition(0)
+    check_read_pattern_output(df, df_part)
 
 
 def test_read_pattern_with_cache(sample_pattern_datasource_with_cache):
     da = sample_pattern_datasource_with_cache.to_dask()
     assert set(da.num.cat.categories) == {2, 3}
     assert set(da.dup.cat.categories) == {1, 2}
-    check_read_pattern_output(sample_pattern_datasource_with_cache)
+    check_read_pattern_output(da.compute(), da.get_partition(0).compute())
 
 
 def test_read_pattern_with_path_as_pattern_str(sample_list_datasource_with_path_as_pattern_str):
     da = sample_list_datasource_with_path_as_pattern_str.to_dask()
     assert set(da.num.cat.categories) == {2}
     assert set(da.dup.cat.categories) == {1, 2}
-    check_read_pattern_output(sample_list_datasource_with_path_as_pattern_str)
+    check_read_pattern_output(da.compute(), da.get_partition(0).compute())
 
 
 def test_read_partition(sample2_datasource, data_filenames):

--- a/intake/source/tests/test_csv.py
+++ b/intake/source/tests/test_csv.py
@@ -84,7 +84,19 @@ def test_discover(sample1_datasource):
     assert info["npartitions"] == 1
 
 
-def test_read(sample1_datasource, data_filenames):
+def test_read_dask(sample1_datasource, data_filenames):
+    sample1_datasource._open_dask()
+    assert sample1_datasource._dask_df is not None
+
+    expected_df = pd.read_csv(data_filenames["sample1"])
+    df = sample1_datasource.read()
+
+    assert expected_df.equals(df)
+
+
+def test_read_pandas(sample1_datasource, data_filenames):
+    sample1_datasource._dask_df = None
+
     expected_df = pd.read_csv(data_filenames["sample1"])
     df = sample1_datasource.read()
 
@@ -95,9 +107,18 @@ def test_read_list(sample_list_datasource, data_filenames):
     df_1 = pd.read_csv(data_filenames["sample2_1"])
     df_2 = pd.read_csv(data_filenames["sample2_2"])
     expected_df = pd.concat([df_1, df_2])
-    df = sample_list_datasource.read()
 
-    assert expected_df.equals(df)
+    sample_list_datasource._open_dask()
+    assert sample_list_datasource._dask_df is not None
+    dask_df = sample_list_datasource.read()
+
+    assert expected_df.equals(dask_df)
+
+    sample_list_datasource._dask_df = None
+    pandas_df = sample_list_datasource.read()
+    assert sample_list_datasource._dask_df is None
+
+    assert expected_df.equals(pandas_df)
 
 
 def test_read_chunked(sample1_datasource, data_filenames):


### PR DESCRIPTION
Attempt at removing Dask as default reader for CSVSource.

Tries to be smart about checking whether Dask DF `source._dask_df` has been created for the source -- if so, call `source._dask_df.compute()` as before. Otherwise, use pandas.

_get_partition(i) treats each input file as a partition if using the pandas backend, otherwise uses `dask.get_partition(i)`. This could potentially lead to inconsistent reads, for example if user calls `source._get_partition(i)`, invoking the pandas backend (and reading `source._files[i]`), then later calls `source.to_dask()`: `source._get_partition(i)` will likely return a different result. Is this a reasonable problem to expect?

Also I suspect that caching pandas dataframes into `source._pandas_dfs` is not a good idea for memory reasons. Should I leave it as-is, make it optional, or remove it?