### PR TITLE
don't use dask for textfiles reader

### DIFF
--- a/intake/source/textfiles.py
+++ b/intake/source/textfiles.py
@@ -84,7 +84,7 @@ class TextFilesSource(base.DataSource):
 
     def read(self):
         self._get_schema()
-        return self.to_dask().compute()
+        return [line for i in range(len(self._files)) for line in self._get_partition(i)]
 
     def to_spark(self):
         from intake_spark.base import SparkHolder


### PR DESCRIPTION
The tests in intake/source/tests/test_text.py now take 0.21s vs 31 seconds... I'm guessing it just takes that long to set up the dask bag?