### PR TITLE
Add intake-dataframe-catalog to plugins.yaml

### DIFF
--- a/docs/plugins.yaml
+++ b/docs/plugins.yaml
@@ -205,3 +205,10 @@
   repo: intake/intake-xarray
   description: Load netCDF, Zarr and other multi-dimensional data
   drivers: xarray_image, netcdf, grib, opendap, rasterio, remote-xarray, zarr
+
+- name: intake-dataframe-catalog
+  repo: ACCESS-NRI/intake-dataframe-catalog
+  ci_yaml: ci.yml
+  description: A searchable table of intake sources and associated metadata
+  drivers: df_catalog
+  conda_channel: accessnri


### PR DESCRIPTION
Simple PR to add intake-dataframe-catalog to the plugin directory in the docs

Closes #723 