### PR TITLE
Allow override of arguments for source from an EntryPoint

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -818,9 +818,14 @@ class EntrypointEntry(CatalogEntry):
             "container": self._container,
         }
 
-    def get(self):
+    def get(self, **kwargs):
         """Instantiate the DataSource for the given parameters"""
-        return self._entrypoint.load()
+        source = self._entrypoint.load()
+        if kwargs:
+            kw = source._captured_init_kwargs.copy()
+            kw.update(kwargs)
+            source = type(source)(**kw)
+        return source
 
 
 class EntrypointsCatalog(Catalog):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -818,14 +818,14 @@ class EntrypointEntry(CatalogEntry):
             "container": self._container,
         }
 
-    def get(self, **kwargs):
+    def __call__(self, **kwargs):
         """Instantiate the DataSource for the given parameters"""
         source = self._entrypoint.load()
         if kwargs:
-            kw = source._captured_init_kwargs.copy()
-            kw.update(kwargs)
-            source = type(source)(**kw)
+            source = source.configure_new(**kwargs)
         return source
+
+    get = __call__
 
 
 class EntrypointsCatalog(Catalog):


### PR DESCRIPTION
Fixes #740 

@dougiesquire : this fixes your situation in as far as you can override any argument for the source. However, you cannot have user parameters, since those are attached to entries, not sources. The thing you point the entry point at is a source and not an entry (which only exist in other catalogs). 

I don't actually know how you have defined the source, so perhaps it would be worth looking at your code to figure that out. 