### PR TITLE
fix fsspec protocol in CSV

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup conda
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: scripts/ci/environment-${{ matrix.CONDA_ENV }}.yml
 

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -5,7 +5,7 @@
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
-from fsspec.core import get_fs_token_paths
+from fsspec.core import get_fs_token_paths, split_protocol
 
 from . import base
 from .utils import reverse_formats, unique_string
@@ -123,7 +123,10 @@ class CSVSource(base.DataSource, base.PatternMixin):
         if self.pattern is None and not glob_in_path:
             self._files = urlpath
         else:
-            self._files = get_fs_token_paths(urlpath)[2]
+            protocol = split_protocol(urlpath[0])[0]
+            self._files = get_fs_token_paths(urlpath, storage_options=self._storage_options)[2]
+            if protocol:
+                self._files = [f"{protocol}://{fn}" for fn in self._files]
 
         return sorted(self._files)
 

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -124,11 +124,12 @@ class CSVSource(base.DataSource, base.PatternMixin):
             self._files = urlpath
         else:
             protocol = split_protocol(urlpath[0])[0]
-            self._files = get_fs_token_paths(urlpath, storage_options=self._storage_options)[2]
+            fs, _, paths = get_fs_token_paths(urlpath, storage_options=self._storage_options)
+            self._files = sorted(paths)
             if protocol:
-                self._files = [f"{protocol}://{fn}" for fn in self._files]
+                self._files = [fs.unstrip_protocol(fn) for fn in self._files]
 
-        return sorted(self._files)
+        return self._files
 
     def _get_schema(self):
         if self._schema is not None:


### PR DESCRIPTION
Fixes https://github.com/intake/intake/issues/750

In splitting out `_files` in https://github.com/intake/intake/pull/734 I inadvertently broke non-local CSV sources. Turns out `fsspec.core.get_fs_token_paths` does not preserve protocol prefixes (presumably because it also returns a FileSystem obj). Intake doesn't have any s3 tests either, so it might be worth getting some mocks to work.

@martindurant This could possibly also be an issue [in the refactor](https://github.com/intake/intake/blob/c3a6f47a802af3db655b49d98aadb9319fb589ac/intake/readers/datatypes.py)