### PR TITLE
Fix get_dir() behavior on Windows

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -502,18 +502,15 @@ def register_plugin_module(mod):
             register_driver(k, v, clobber=True)
 
 
-def get_dir(path):
-    if "://" in path:
-        protocol, _ = split_protocol(path)
-        out = get_filesystem_class(protocol)._parent(path)
-        if "://" not in out:
-            # some FSs strip this, some do not
-            out = protocol + "://" + out
-        return out
-    path = make_path_posix(os.path.join(os.getcwd(), os.path.dirname(path)))
-    if path[-1] != "/":
-        path += "/"
-    return path
+def get_dir(path: str) -> str:
+    """Get the absolute path of the directory of the file"""
+    protocol, pure_path = split_protocol(path)
+    dirname = os.path.dirname(pure_path)
+    if protocol:
+        # leave the path without '/' in the end
+        return f"{protocol}://{dirname}"
+    # get absolute path, convert to posix and add '/' in the end
+    return f"{os.path.abspath(dirname).replace(os.sep, r'/')}/"
 
 
 class YAMLFileCatalog(Catalog):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -11,7 +11,7 @@ import os
 import warnings
 
 import entrypoints
-from fsspec import get_filesystem_class, open_files
+from fsspec import open_files
 from fsspec.core import split_protocol
 
 from .. import __version__


### PR DESCRIPTION
This PR fixes `get_dir()` behavior on the Windows platform.

It is supposed to replace #743, and should be compatible with #761.

Function `get_dir()` is rewritten according to the tests in `test_local.test_get_dir()`, but the expected behavior is quite weird.
It looks like the real problem is somewhere else, but we are trying to patch it here.