### PR TITLE
Ensure "/" between CATALOG_DIR and file or subfolder

### DIFF
--- a/docs/source/transforms.rst
+++ b/docs/source/transforms.rst
@@ -36,7 +36,7 @@ test suite.
         description: a local data file
         driver: csv
         args:
-          urlpath: '{{ CATALOG_DIR }}cache_data/states.csv'
+          urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
 
 We now show two ways to apply a super-simple transform to this data,
 which selects two of the dataframe's columns.

--- a/intake/catalog/tests/catalog_alias.yml
+++ b/intake/catalog/tests/catalog_alias.yml
@@ -3,7 +3,7 @@ sources:
     description: a local data file
     driver: csv
     args:
-      urlpath: '{{ CATALOG_DIR }}cache_data/states.csv'
+      urlpath: '{{ CATALOG_DIR }}/cache_data/states.csv'
   arr_cache:
     description: small array
     driver: numpy

--- a/intake/catalog/tests/catalog_caching.yml
+++ b/intake/catalog/tests/catalog_caching.yml
@@ -40,10 +40,10 @@ sources:
     driver: csv
     cache:
       - argkey: urlpath
-        regex: '{{ CATALOG_DIR }}cache_data'
+        regex: '{{ CATALOG_DIR }}/cache_data'
         type: file
     args:
-      urlpath: ['{{ CATALOG_DIR }}cache_data/states.csv', '{{ CATALOG_DIR }}cache_data/states.csv']
+      urlpath: ['{{ CATALOG_DIR }}/cache_data/states.csv', '{{ CATALOG_DIR }}/cache_data/states.csv']
   test_bad_type_cache_spec:
     description: cache a csv file from the local filesystem
     driver: csv

--- a/intake/source/csv.py
+++ b/intake/source/csv.py
@@ -32,11 +32,11 @@ class CSVSource(base.DataSource, base.PatternMixin):
             such as ``'s3://'``. May include glob wildcards or format pattern strings.
             Some examples:
 
-            - ``{{ CATALOG_DIR }}data/precipitation.csv``
+            - ``{{ CATALOG_DIR }}/data/precipitation.csv``
             - ``s3://data/*.csv``
             - ``s3://data/precipitation_{state}_{zip}.csv``
             - ``s3://data/{year}/{month}/{day}/precipitation.csv``
-            - ``{{ CATALOG_DIR }}data/precipitation_{date:%Y-%m-%d}.csv``
+            - ``{{ CATALOG_DIR }}/data/precipitation_{date:%Y-%m-%d}.csv``
         csv_kwargs : dict
             Any further arguments to pass to Dask's read_csv (such as block size)
             or to the `CSV parser <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html>`_

--- a/intake/tests/catalog_nested.yml
+++ b/intake/tests/catalog_nested.yml
@@ -3,4 +3,4 @@ sources:
     description: References catalog_nested_sub.yml
     driver: yaml_file_cat
     args:
-      path: "{{ CATALOG_DIR }}__unit_test_catalog_nested_sub.yml"
+      path: "{{ CATALOG_DIR }}/__unit_test_catalog_nested_sub.yml"


### PR DESCRIPTION
This PR makes links to files and subfolders in catalog files consistent, according to #764 