### PR TITLE
Fix get_dir() using fsspec

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -11,7 +11,7 @@ import os
 import warnings
 
 import entrypoints
-from fsspec import get_filesystem_class, open_files
+from fsspec import open_files
 from fsspec.core import split_protocol
 
 from .. import __version__

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -502,18 +502,11 @@ def register_plugin_module(mod):
             register_driver(k, v, clobber=True)
 
 
-def get_dir(path):
-    if "://" in path:
-        protocol, _ = split_protocol(path)
-        out = get_filesystem_class(protocol)._parent(path)
-        if "://" not in out:
-            # some FSs strip this, some do not
-            out = protocol + "://" + out
-        return out
-    path = make_path_posix(os.path.join(os.getcwd(), os.path.dirname(path)))
-    if path[-1] != "/":
-        path += "/"
-    return path
+def get_dir(path: str) -> str:
+    """Get the directory path of the file"""
+    protocol, pure_path = split_protocol(path)
+    dirname = os.path.dirname(pure_path)
+    return f"{protocol}://{dirname}" if protocol else dirname
 
 
 class YAMLFileCatalog(Catalog):

--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -12,7 +12,7 @@ import warnings
 
 import entrypoints
 from fsspec import open_files
-from fsspec.core import split_protocol
+from fsspec.core import split_protocol, url_to_fs
 
 from .. import __version__
 from ..source import get_plugin_class, register_driver
@@ -504,9 +504,8 @@ def register_plugin_module(mod):
 
 def get_dir(path: str) -> str:
     """Get the directory path of the file"""
-    protocol, pure_path = split_protocol(path)
-    dirname = os.path.dirname(pure_path)
-    return f"{protocol}://{dirname}" if protocol else dirname
+    fs, fspath = url_to_fs(path)
+    return fs._parent(fspath)
 
 
 class YAMLFileCatalog(Catalog):

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -125,17 +125,17 @@ def test_get_dir():
     assert get_dir("https://example.com/catalog.yml") == "https://example.com"
     path = "example/catalog.yml"
     out = get_dir(path)
-    assert os.path.isabs(out)
-    assert out.endswith("/example/")
+    assert not os.path.isabs(out)
+    assert out.endswith("example")
     path = "/example/catalog.yml"
     out = get_dir(path)
     # it's ok if the first two chars indicate drive for win (C:)
-    assert "/example/" in [out, out[2:]]
+    assert "/example" in [out, out[2:]]
     path = "example"
     out = get_dir(path)
-    assert os.path.isabs(out)
+    assert not os.path.isabs(out)
     assert not out.endswith("/example")
-    assert out.endswith("/")
+    assert not out.endswith("/")
 
 
 def test_entry_dir_function(catalog1):

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -121,21 +121,22 @@ def test_use_source_plugin_from_config(catalog1):
 
 
 def test_get_dir():
+    # Protocols must not be stripped
     assert get_dir("file:///path/catalog.yml") == "file:///path"
     assert get_dir("https://example.com/catalog.yml") == "https://example.com"
-    path = "example/catalog.yml"
-    out = get_dir(path)
+    assert get_dir("memory://file.txt") == "memory://"
+    
+    # Relative path must stay relative
+    relative_path = "superdir/example/catalog.yml"
+    out = get_dir(relative_path)
     assert not os.path.isabs(out)
     assert out.endswith("example")
-    path = "/example/catalog.yml"
-    out = get_dir(path)
-    # it's ok if the first two chars indicate drive for win (C:)
-    assert "/example" in [out, out[2:]]
-    path = "example"
-    out = get_dir(path)
-    assert not os.path.isabs(out)
-    assert not out.endswith("/example")
-    assert not out.endswith("/")
+
+    # Absolute path must stay absolute
+    absolute_path = "/superdir/example/catalog.yml"
+    out = get_dir(absolute_path)
+    assert os.path.isabs(out)
+    assert out.endswith("/example")
 
 
 def test_entry_dir_function(catalog1):

--- a/intake/catalog/tests/test_local.py
+++ b/intake/catalog/tests/test_local.py
@@ -125,13 +125,11 @@ def test_get_dir():
     assert get_dir("file:///path/catalog.yml") == "file:///path"
     assert get_dir("https://example.com/catalog.yml") == "https://example.com"
     assert get_dir("memory://file.txt") == "memory://"
-    
     # Relative path must stay relative
     relative_path = "superdir/example/catalog.yml"
     out = get_dir(relative_path)
     assert not os.path.isabs(out)
     assert out.endswith("example")
-
     # Absolute path must stay absolute
     absolute_path = "/superdir/example/catalog.yml"
     out = get_dir(absolute_path)


### PR DESCRIPTION
This is another solution for #739, and it works better than #768.
However, it breaks catalogs created in memory, like in `test_fsspec_integration`