### PR TITLE
Remove cache and test for py38

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CONDA_ENV: [py39, py310, py311, pip]
+        CONDA_ENV: [py38, py39, py310, py311, pip]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/intake/readers/datatypes.py
+++ b/intake/readers/datatypes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from itertools import chain
-from functools import cache
+from functools import lru_cache as cache
 from typing import Any, Optional
 
 import fsspec

--- a/intake/readers/metadata.py
+++ b/intake/readers/metadata.py
@@ -9,6 +9,8 @@ https://specs.frictionlessdata.io/data-resource/
 """
 from __future__ import annotations
 
+from typing import List
+
 metadata_fields = {
     "description": (str, "one-line description of the dataset"),
     "text": (str, "long-form prose description of the dataset"),
@@ -16,16 +18,16 @@ metadata_fields = {
         str,
         "most recent datum in the set, ISO format",
     ),  # timespan would be in "data" as an extent
-    "imports": (list[str, ...], "top-level packages needed to read this"),
+    "imports": (List[str], "top-level packages needed to read this"),
     "environment": (str, "YAML string or URL of a conda env spec"),  # or requirements.txt
-    "references": (list[str], "URLs with further information relating to this"),
+    "references": (List[str], "URLs with further information relating to this"),
     "repr": (str, "string form of output"),
     "data": (
         dict,
         "any data-specific details, such as field types, missing values" "bounds or statistics",
     ),
     "history": (
-        list[dict],
+        List[dict],
         "Time-ordered list of operations done to get this data. Keys are ISO timestamps.",
     ),
     "datashape": (str, "if applicable, may have datashape, dtype(s), jsonschema or similar"),

--- a/intake/readers/metadata.py
+++ b/intake/readers/metadata.py
@@ -7,6 +7,7 @@ We may decide to have different recommended keys for data versus readers/pipelin
 For a possible schema we could decide to use, see
 https://specs.frictionlessdata.io/data-resource/
 """
+from __future__ import annotations
 
 metadata_fields = {
     "description": (str, "one-line description of the dataset"),

--- a/intake/readers/namespaces.py
+++ b/intake/readers/namespaces.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import re
-from functools import cache
+from functools import lru_cache as cache
 from typing import Iterable
 
 from intake.readers.utils import Completable, subclasses

--- a/intake/readers/search.py
+++ b/intake/readers/search.py
@@ -1,5 +1,7 @@
 """Find datasets meeting some complex criteria"""
 
+from __future__ import annotations
+
 from intake.readers.entry import ReaderDescription
 
 

--- a/intake/readers/tests/cats/test_sql.py
+++ b/intake/readers/tests/cats/test_sql.py
@@ -60,6 +60,7 @@ def sqlite_with_data(tmpdir):
 
 
 def test_sqlite_pandas(sqlite_with_data):
+    pytest.importorskip("pandas", minversion="2", reason="Not working on earlier version of pandas")
     data = datatypes.SQLQuery(conn=f"sqlite:///{sqlite_with_data}", query="oi")
     reader = readers.PandasSQLAlchemy(data)
     out = reader.read()
@@ -78,6 +79,7 @@ def test_sqlite_duck_with_pandas_input(sqlite_with_data):
 
 
 def test_cat(sqlite_with_data):
+    pytest.importorskip("pandas", minversion="2", reason="Not working on earlier version of pandas")
     data = datatypes.Service(url=f"sqlite:///{sqlite_with_data}")
     reader = catalogs.SQLAlchemyCatalog(data)
     cat = reader.read()

--- a/intake/readers/utils.py
+++ b/intake/readers/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib.metadata
 import numbers
 import re
-from functools import cache
+from functools import lru_cache as cache
 from hashlib import md5
 from itertools import zip_longest
 from typing import Any, Iterable, Mapping


### PR DESCRIPTION
Currently, intake 2.0 supports Python 3.8, and `functools.cache` was first added in Python 3.9. 

https://github.com/intake/intake/blob/6426267e4f01ed55b79c15ad3e514b2176442720/pyproject.toml#L25