### PR TITLE
Use python-duckdb for py311 test environment

### DIFF
--- a/scripts/ci/environment-py311.yml
+++ b/scripts/ci/environment-py311.yml
@@ -39,5 +39,5 @@ dependencies:
   - pre-commit
   - pytest-postgresql
   - psycopg
-  - duckdb
+  - python-duckdb
   - siphon


### PR DESCRIPTION
This PR replaces [linux only](https://anaconda.org/conda-forge/duckdb) `duckdb` package to [OS-agnostic one](https://anaconda.org/conda-forge/python-duckdb) for python 3.11 tests environment.