### PR TITLE
compat: fix old caching behaviour

### DIFF
--- a/intake/_version.py
+++ b/intake/_version.py
@@ -1,0 +1,1 @@
+__version__ = "0.dev"

--- a/intake/source/base.py
+++ b/intake/source/base.py
@@ -148,7 +148,7 @@ class DataSourceBase(DictSerialiseMixin):
 
     def _get_cache(self, urlpath):
         """The base class does not interact with caches"""
-        return urlpath
+        return [urlpath]
 
     def discover(self):
         """Open resource and populate the source attributes."""


### PR DESCRIPTION
Since the caching class no longer exists, the supreclass no-op got exposed, which had a different return type