### PR TITLE
Allow old-style entrypoints for newer python

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -932,6 +932,7 @@ class EntrypointsCatalog(Catalog):
         eps = entry_points()
         if hasattr(eps, "select"):  # Python 3.10+ / importlib_metadata >= 3.9.0
             catalogs = eps.select(group=self._entrypoints_group)
+            catalogs = {ep.name: ep for ep in catalogs}
         else:
             catalogs = eps.get("intake.drivers", [])
         self.name = self.name or "EntrypointsCatalog"


### PR DESCRIPTION
@dsroberts

Fixes #787 

Note that intake.cat is not (yet) a feature in Take2 (>=2.0.0). I have not yet decided on the best way to implement it, but I am tempted to say it should be by imports alone, where the things to import are in the config.