### PR TITLE
readd entrypoints for old style sources in this package

### DIFF
--- a/intake/catalog/local.py
+++ b/intake/catalog/local.py
@@ -394,6 +394,10 @@ class CatalogParser(object):
                 )
                 continue
 
+            elif "module" in plugin_source:
+                import intake
+
+                intake.import_name(plugin_source["module"])
             elif "dir" in plugin_source:
                 self.error(
                     "The key 'dir', and in general the feature of registering "
@@ -555,7 +559,7 @@ class CatalogParser(object):
             self.error("catalog must be a dictionary", data)
             return
         if (data.get("version", None) or data.get("metadata", {}).get("version", None) or 1) > 1:
-            raise VersionError("Not a V1 Catalog; perhaps use intake.from_yaml_file")
+            raise VersionError("Not a V1 Catalog; perhaps use intake.open_catalog")
 
         return dict(
             plugin_sources=self._parse_plugins(data),

--- a/intake/readers/convert.py
+++ b/intake/readers/convert.py
@@ -301,6 +301,7 @@ class GeoDataFrameToSTACCatalog(BaseConverter):
             signer=self.metadata.get("signer"),
             prefer=self.metadata.get("prefer"),
             cls="ItemCollection",
+            metadata=self.metadata,
         ).read()
 
 

--- a/intake/readers/datatypes.py
+++ b/intake/readers/datatypes.py
@@ -677,6 +677,7 @@ comp_magic = {
     (0, b"\x1f\x8b"): "gzip",
     (0, b"BZh"): "bzip2",
     (0, b"(\xc2\xb5/\xc3\xbd"): "zstd",
+    (0, b"\xff\x06\x00\x00sNaPpY"): "sz",  # stream framed format
 }
 container_magic = {
     # these are like datatypes making filesystems

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1014,8 +1014,8 @@ class RasterIOXarrayReader(FileReader):
             if k in kwargs
         }
 
-        with fsspec.open_files(data.url, **(data.storage_options or {})) as ofs:
-            bits = [open_rasterio(of, **kwargs) for of in ofs]
+        ofs = fsspec.open_files(data.url, **(data.storage_options or {}))
+        bits = [open_rasterio(of.open(), **kwargs) for of in ofs]
         if len(bits) == 1:
             return bits
         else:

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -129,7 +129,7 @@ class BaseReader(Tokenizable, PipelineMixin):
 
     def to_reader(self, outtype: tuple[str] | str | None = None, reader: str | None = None, **kw):
         """Make a different reader for the data used by this reader"""
-        return self.data.to_reader(outtype=outtype, reader=reader, **kw)
+        return self.data.to_reader(outtype=outtype, reader=reader, metadata=self.metadata, **kw)
 
     def auto_pipeline(self, outtype: str | tuple[str], avoid: list[str] | None = None):
         from intake import auto_pipeline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,11 @@ exclude = "__init__.py"
 ignore = "E,W"
 select = "F,E101,E111,E501"
 max-line-length = 100
+
+[project.entry-points."intake.drivers"]
+csv = "intake.source.csv:CSVSource"
+jsonfiles = "intake.source.jsonfiles:JSONFileSource"
+numpy = "intake.source.npy:NPySource"
+tiled_cat = "intake.source.tiled:TiledCatalog"
+textfiles = "intake.source.textfiles:TextFilesSource"
+zarr = "intake.source.zarr:ZarrArraySource"


### PR DESCRIPTION
Fixes https://github.com/intake/intake-xarray/issues/140

@forestbat , if you wouldn't mind testing this. I am unsure whether I want to pollute the top-level namespace with these deprecated open* names. Do you think it would be reasonable to hide them behind a config option, or require calling a function to see them?