### PR TITLE
Update class names in pandas/xarray converters

### DIFF
--- a/intake/readers/convert.py
+++ b/intake/readers/convert.py
@@ -108,12 +108,12 @@ class PandasToGeopandas(BaseConverter):
 
 
 class XarrayToPandas(BaseConverter):
-    instances = {"xarray:DataSet": "pandas:DataFrame"}
-    func = "xarray:DataSet.to_dataframe"
+    instances = {"xarray:Dataset": "pandas:DataFrame"}
+    func = "xarray:Dataset.to_dataframe"
 
 
 class PandasToXarray(BaseConverter):
-    instances = {"pandas:DataFrame": "xarray:DataSet"}
+    instances = {"pandas:DataFrame": "xarray:Dataset"}
     func = "xarray:Dataset.from_dataframe"
 
 


### PR DESCRIPTION
I noticed a couple typos leading to errors like
```
AttributeError: module 'xarray' has no attribute 'DataSet'. Did you mean: 'Dataset'?
```


Simple script to recreate the error:
```
import intake
import xarray as xr 

url = "gs://weatherbench2/datasets/era5/1959-2022-6h-1440x721.zarr"
# xr.open_dataset(url, engine="zarr", consolidated=True)

reader = intake.reader_from_call(
    'xr.open_dataset(url, engine="zarr", consolidated=True)'
)
```