### PR TITLE
differentiate http reader for zarr via xpublish-intake

### DIFF
--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1021,7 +1021,7 @@ class XArrayDatasetReader(FileReader):
             if (
                 isinstance(data, datatypes.FileData)
                 and data.url.startswith("http")
-                and not datatypes.Zarr
+                and not isinstance(data, datatypes.Zarr)
             ):
                 # special case, because xarray would assume a DAP endpoint
                 f = fsspec.open(data.url, **(data.storage_options or {})).open()

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1019,8 +1019,8 @@ class XArrayDatasetReader(FileReader):
         else:
             # TODO: recognise fsspec URLs, and optionally use open_local for engines tha need it
             if (
-                isinstance(data, datatypes.FileData) 
-                and data.url.startswith("http") 
+                isinstance(data, datatypes.FileData)
+                and data.url.startswith("http")
                 and not datatypes.Zarr
             ):
                 # special case, because xarray would assume a DAP endpoint

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1018,7 +1018,11 @@ class XArrayDatasetReader(FileReader):
             return open_mfdataset(data.url, **kw)
         else:
             # TODO: recognise fsspec URLs, and optionally use open_local for engines tha need it
-            if isinstance(data, datatypes.FileData) and data.url.startswith("http") and not datatypes.Zarr:
+            if (
+                isinstance(data, datatypes.FileData) 
+                and data.url.startswith("http") 
+                and not datatypes.Zarr
+            ):
                 # special case, because xarray would assume a DAP endpoint
                 f = fsspec.open(data.url, **(data.storage_options or {})).open()
                 return open_dataset(f, **kw)

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1018,7 +1018,7 @@ class XArrayDatasetReader(FileReader):
             return open_mfdataset(data.url, **kw)
         else:
             # TODO: recognise fsspec URLs, and optionally use open_local for engines tha need it
-            if isinstance(data, datatypes.FileData) and data.url.startswith("http"):
+            if isinstance(data, datatypes.FileData) and data.url.startswith("http") and not datatypes.Zarr:
                 # special case, because xarray would assume a DAP endpoint
                 f = fsspec.open(data.url, **(data.storage_options or {})).open()
                 return open_dataset(f, **kw)


### PR DESCRIPTION
This prevents urlpaths like `http://0.0.0.0:9005/datasets/air/zarr` that are being served by `xpublish-intake` from being served by the DAP end point and instead being served by the input zarr engine information.

@abkfenris Figured out the necessary code change.

Fixes https://github.com/intake/intake/issues/809