### PR TITLE
revise LlamaServerReader

### DIFF
--- a/intake/readers/convert.py
+++ b/intake/readers/convert.py
@@ -5,11 +5,13 @@ By convention, functions here do not change the data, just how it is held.
 from __future__ import annotations
 
 import re
+from urllib.parse import urljoin
 from functools import lru_cache
 from itertools import chain
 
 from intake import import_name, conf
-from intake.readers import BaseData, BaseReader, readers
+from intake.readers.datatypes import OpenAIService
+from intake.readers import BaseData, BaseReader, readers, LlamaServerReader, OpenAIReader
 from intake.readers.utils import all_to_one, subclasses, safe_dict
 
 
@@ -412,6 +414,31 @@ class DataFrameToMetadata(BaseConverter):
             out["shape"] = [x.count(), len(x.columns)]
             out["schema"] = safe_dict(x.schema)
         return safe_dict(out)
+
+
+class GGUFToLlamaCPPService(BaseConverter):
+    instances = {"intake.readers.datatypes:GGUF": "intake.readers.datatypes:LlamaCPPService"}
+
+    def run(self, x, **kwargs):
+        return LlamaServerReader(x).read(**kwargs)
+
+
+class LLamaCPPServiceToOpenAIService(BaseConverter):
+    instances = {
+        "intake.readers.datatypes:LlamaCPPService": "intake.readers.datatypes:OpenAIService"
+    }
+
+    def run(self, x, options=None):
+        url = urljoin(x.url, "/v1")
+        service = OpenAIService(url=url, key="none", options=options)
+        return service
+
+
+class OpenAIServiceToOpenAIClient(BaseConverter):
+    instance = {"intake.readers.datatypes:OpenAIService": "openai:OpenAI"}
+
+    def run(self, x):
+        return OpenAIReader(x).read()
 
 
 def convert_class(data, out_type: str):

--- a/intake/readers/convert.py
+++ b/intake/readers/convert.py
@@ -435,7 +435,7 @@ class LLamaCPPServiceToOpenAIService(BaseConverter):
 
 
 class OpenAIServiceToOpenAIClient(BaseConverter):
-    instance = {"intake.readers.datatypes:OpenAIService": "openai:OpenAI"}
+    instances = {"intake.readers.datatypes:OpenAIService": "openai:OpenAI"}
 
     def run(self, x):
         return OpenAIReader(x).read()

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -580,7 +580,7 @@ class LlamaServerReader(BaseReader):
 
     def _read(self, data, log_file="llama-cpp.log", **kwargs):
         startup_timeout = kwargs.pop("startup_timeout", 60)
-        callback = kwargs.pop("callback")
+        callback = kwargs.pop("callback", None)
 
         port = kwargs.pop("port", 8080)
         host = kwargs.pop("host", "127.0.0.1")
@@ -595,6 +595,7 @@ class LlamaServerReader(BaseReader):
         path = self._local_model_path(data, callback=callback)
         cmd = [server_path, "-m", path, "--host", host, "--port", str(port), "--log-disable"]
         for k, v in kwargs.items():
+            k = k.replace("_", "-")
             if not k.startswith("-"):
                 k = f"-{k}"
             if v not in [None, ""]:
@@ -619,7 +620,9 @@ class LlamaServerReader(BaseReader):
                 )
 
         atexit.register(P.terminate)
-        return intake.readers.datatypes.LlamaCPPService(url=URL, options={"Process": P})
+        return intake.readers.datatypes.LlamaCPPService(
+            url=URL, options={"Process": P, "log_file": log_file}
+        )
 
 
 class LlamaCPPCompletion(BaseReader):

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -14,7 +14,7 @@ import intake.readers.datatypes
 from intake import import_name, logger
 from intake.readers import datatypes
 from intake.readers.mixins import PipelineMixin
-from intake.readers.utils import Tokenizable, subclasses
+from intake.readers.utils import Tokenizable, subclasses, port_in_use
 
 
 class BaseReader(Tokenizable, PipelineMixin):
@@ -586,6 +586,9 @@ class LlamaServerReader(BaseReader):
         port = kwargs.pop("port", 8080)
         host = kwargs.pop("host", "127.0.0.1")
         URL = f"http://{host}:{port}"
+
+        if port_in_use(host, port):
+            raise RuntimeError(f"{URL} in use.")
 
         import requests
         import subprocess

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -548,6 +548,7 @@ class LlamaServerReader(BaseReader):
 
         protocol, _ = split_protocol(data.url)
         if protocol is None:
+            # no protocol means local path
             return data.url
 
         storage_options = {} if data.storage_options is None else data.storage_options

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -513,7 +513,7 @@ class SKLearnExampleReader(BaseReader):
 class LlamaServerReader(BaseReader):
     """Create llama.cpp server using local pretrained model file"""
 
-    output_instance = "intake.readers.datatypes:ChatService"
+    output_instance = "intake.readers.datatypes:LlamaCPPService"
     implements = {datatypes.GGUF}
     imports = {"requests"}
 
@@ -652,6 +652,18 @@ class LlamaCPPEmbedding(BaseReader):
             headers={"Content-Type": "application/json"},
         )
         return r.json()["embedding"]
+
+
+class OpenAIReader(BaseReader):
+    implements = {datatypes.OpenAIService}
+    imports = {"openai"}
+    output_instance = "openai:OpenAI"
+
+    def _read(self, data, **kwargs):
+        import openai
+
+        client = openai.Client(api_key=data.key, base_url=data.url, **kwargs)
+        return client
 
 
 class OpenAICompletion(BaseReader):

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -534,8 +534,7 @@ class LlamaServerReader(BaseReader):
         path = cls._find_executable()
         return imports & (path is not None)
 
-    def _read(self, data, log_file="out.log", **kwargs):
-        # TODO: list common options, like PORT
+    def _read(self, data, log_file="llama-cpp.log", **kwargs):
         startup_timeout = kwargs.pop("startup_timeout", 60)
         port = kwargs.pop("port", 8080)
         host = kwargs.pop("host", "127.0.0.1")
@@ -547,7 +546,7 @@ class LlamaServerReader(BaseReader):
 
         f = open(log_file, "wb")
         server_path = self._find_executable()
-        cmd = [server_path, "-m", data.url, "--host", host, "--port", str(port)]
+        cmd = [server_path, "-m", data.url, "--host", host, "--port", str(port), "--log-disable"]
         for k, v in kwargs.items():
             if not k.startswith("-"):
                 k = f"-{k}"

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -574,21 +574,8 @@ class LlamaServerReader(BaseReader):
         sha = fs._mapper(path)
         cached_fn = os.path.join(fs.storage[-1], sha)
 
-        with fs.fs.open(path) as f:
-            callback.set_size(fs.info(path)["size"])
-
-            cached = open(cached_fn, "wb")
-            chunk = True
-            try:
-                while chunk:
-                    chunk = f.read(fs.blocksize)
-                    cached.write(chunk)
-                    callback.relative_update(len(chunk))
-            finally:
-                callback.close()
-                cached.close()
-
-            return cached_fn
+        fs.fs.get_file(path, cached_fn, callback=callback)
+        return cached_fn
 
     def _read(self, data, log_file="llama-cpp.log", **kwargs):
         startup_timeout = kwargs.pop("startup_timeout", 60)

--- a/intake/readers/utils.py
+++ b/intake/readers/utils.py
@@ -483,3 +483,28 @@ def safe_dict(x):
     if isinstance(x, typing.Iterable):
         return [safe_dict(v) for v in x]
     return str(x)
+
+
+def port_in_use(host, port=None):
+    import socket
+
+    if isinstance(host, tuple):
+        host, port = host
+    elif isinstance(host, str) and host.startswith("http"):
+        from urllib.parse import urlparse
+
+        parsed = urlparse(host)
+        host = parsed.hostname
+        if parsed.port is None:
+            port = port
+
+    if (port is None) or (host is None):
+        raise ValueError(f"host={host} and port={port} is not valid.")
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.connect((host, int(port)))
+        s.shutdown(2)
+        return True
+    except:  # noqa: E722
+        return False


### PR DESCRIPTION
* safetensors requires a transformation step, support removed for now
* transformers is not required to run llama.cpp
* extend check_imports to search for llama.cpp executable
* set default port and host to avoid parsing from output
* add a health check