### PR TITLE
[feature] cache system prompt file to disk for LlamaServerReader

### DIFF
--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -520,6 +520,7 @@ class LlamaServerReader(BaseReader):
 
     host: (str) hostname for the the server to listen on, default: 127.0.0.1
     port: (int) port number for the server to listen on, default: 0, which means first free port
+    system_prompt_file: (uri) Special handling here to support fsspec uri where the file is cached to disk first
 
     Additional kwargs not passed to llama.cpp
 
@@ -661,10 +662,15 @@ class LlamaServerReader(BaseReader):
             k = k.replace("_", "-")
             if not k.startswith("-"):
                 k = f"--{k}"
-            if v not in [None, ""]:
+
+            if k == "--system-prompt-file":
+                path = fsspec.open_local(f"simplecache::{v}")
+                cmd.extend([str(k), path])
+            elif v not in [None, ""]:
                 cmd.extend([str(k), str(v)])
             else:
                 cmd.append(str(k))
+
         P = subprocess.Popen(cmd, stdout=f, stderr=f)
         import time
 


### PR DESCRIPTION
In llama.cpp the sytem prompt can be modified by supplying a local json file, [example](https://github.com/AlbertDeFusco/system-prompts/blob/main/llama.cpp/kitty.json). This PR provides support for FSSpec URI and caches to local disk when the server starts. 

```python
In [1]: import intake

In [2]: gguf = intake.readers.datatypes.GGUF('./llama-2-7b-chat-hf_Q4_K_M.gguf')

In [3]: service = intake.readers.readers.LlamaServerReader(gguf, system_prompt_file='github://albertdefusco:system-prompts@main/llama.cpp/kitty.json').read()

In [4]: service.options["Process"].args
Out[4]: 
['<prefix>/bin/llama-server',
 '-m',
 './llama-2-7b-chat-hf_Q4_K_M.gguf',
 '--host',
 '127.0.0.1',
 '--port',
 '57175',
 '--log-disable',
 '--system-prompt-file',
 '/var/folders/cg/wyhz9cvx06vdt65k8tr31trc0000gp/T/tmped68obcc/4dde577007cae84cbaf8a504e9c99a479fc93ccad8818589c8359e977baed6c2']

In [5]: !cat /var/folders/cg/wyhz9cvx06vdt65k8tr31trc0000gp/T/tmped68obcc/4dde577007cae84cbaf8a504e9c99a479fc93ccad8818589c8359e977baed6c2
{
    "prompt": "You are a cat. You will Begin every response with 'I am a kitty, but'. You will end every response with 'meow meow'.",
    "anti_prompt": "User:",
    "assistant_name": "Assistant:"
}

In [6]: 
```