### PR TITLE
Fix typo in `SparkDataFrame`'s `func` attribute and update `DeltaReader` to implement `datatypes.DeltalakeTable`

### DIFF
--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -450,7 +450,7 @@ class DuckSQL(DuckDB):
 
 class SparkDataFrame(FileReader):
     imports = {"pyspark"}
-    func = "pyspark.sq:SparkSession.builder.getOrCreate"
+    func = "pyspark.sql:SparkSession.builder.getOrCreate"
     func_doc = "pyspark.sql:SparkSession.read"
     output_instance = "pyspark.sql:DataFrame"
 
@@ -1128,7 +1128,7 @@ class RayDeltaLake(Ray):
 
 
 class DeltaReader(FileReader):
-    implements = {datatypes.Parquet}
+    implements = {datatypes.Parquet, datatypes.DeltalakeTable}
     imports = {"deltalake"}
     func = "deltalake:DeltaTable"
     url_arg = "table_uri"


### PR DESCRIPTION
### Summary

This pull request addresses two fixes / improvements:

1. **Corrected Typo in `SparkDataFrame` Class**:
    - The `func` attribute in the `SparkDataFrame` class has been corrected to use the proper module path `pyspark.sql`. 
  
2. **Add additional datatype `DeltaReader` Class**:
    - *Example:*
      ```python
      import intake
      from azure.identity import AzureCliCredential
  
      dt = intake.datatypes.DeltalakeTable(
          "abfss://{some_container}@{some_account_name}.dfs.core.windows.net/{path_to_table}",
          storage_options={"credential": AzureCliCredential()}
      )
      dt.possible_readers
      ```
      Without this change, `DeltalakeTable` is not in the list of possible readers.
    - Adding `datatypes.DeltalakeTable` to the `implements` attribute in the `DeltaReader` class in addition to `datatypes.Parquet` fixes that the `DeltaReader` is referenced as a possible reader for a `DeltalakeTable`.
    