### PR TITLE
Open our own files for xarray

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         OS: [ubuntu-latest, windows-latest]
-        CONDA_ENV: [py38, py39, py310, py311, py312, pip]
+        CONDA_ENV: [py39, py310, py311, py312, py313, pip]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1271,11 +1271,15 @@ class XArrayDatasetReader(FileReader):
                 kw["engine"] = "tiledb"
                 if data.options:
                     kw.setdefault("backend_kwargs", {})["config"] = data.options
-        if kw.get("engine", "") in ["zarr", "kerchunk", "h5netcdf"] and data.storage_options:
+            elif isinstance(data, datatypes.NetCDF3):
+                kw["engine"] = "scipy"
+            elif isinstance(data, datatypes.HDF5):
+                kw["engine"] = "h5netcdf"
+        if kw.get("engine", "") in ["zarr", "kerchunk"] and data.storage_options:
             kw.setdefault("backend_kwargs", {})["storage_options"] = data.storage_options
-        if isinstance(data, datatypes.HDF5):
+        if isinstance(data, (datatypes.HDF5, datatypes.NetCDF3)):
             kw.setdefault("engine", "h5netcdf")
-            if data.path:
+            if getattr(data, "path", False):
                 kw["group"] = data.path
         auth = kw.pop("auth", "")
         if isinstance(data, datatypes.OpenDAP) and auth and kw.get("engine", "") == "pydap":
@@ -1293,13 +1297,18 @@ class XArrayDatasetReader(FileReader):
         if isinstance(data.url, (tuple, set, list)) and len(data.url) == 1:
             return open_dataset(data.url[0], **kw)
         elif (isinstance(data.url, (tuple, set, list)) and len(data.url) > 1) or (
-            isinstance(data.url, str) and "*" in data.url and not isinstance(data, datatypes.Zarr)
+            isinstance(data.url, str) and "*" in data.url
         ):
-            ofs = [_.open() for _ in fsspec.open_files(data.url, **(data.storage_options or {}))]
+            if isinstance(data, (datatypes.Zarr, datatypes.OpenDAP)):
+                ofs = data.url
+            elif open_local:
+                ofs = fsspec.open_local(data.url, **(data.storage_options or {}))
+            else:
+                ofs = [
+                    _.open() for _ in fsspec.open_files(data.url, **(data.storage_options or {}))
+                ]
             return open_mfdataset(ofs, **kw)
         else:
-            # TODO: recognise fsspec URLs, and optionally use open_local for engines tha need it
-            #  see fsspec.utils.can_be_local
             if (
                 isinstance(data, datatypes.FileData)
                 and (
@@ -1336,14 +1345,18 @@ class XArrayPatternReader(XArrayDatasetReader):
 
     # should we have an explicit pattern type data input?
 
-    def _read(self, data, open_local=False, **kw):
+    def _read(self, data, open_local=False, pattern=None, **kw):
         import pandas as pd
         from intake.readers.utils import pattern_to_glob
         from intake.source.utils import reverse_formats
 
-        url = pattern_to_glob(data.url)
-        fs, _, paths = fsspec.get_fs_token_paths(url, **(data.storage_options or {}))
-        val_dict = reverse_formats(data.url, paths)
+        if isinstance(data.url, str):
+            url = pattern_to_glob(data.url)
+            fs, _, paths = fsspec.get_fs_token_paths(url, **(data.storage_options or {}))
+            val_dict = reverse_formats(data.url, paths)
+        else:
+            paths = data.url
+            val_dict = reverse_formats(pattern, data.url)
         indices = [pd.Index(v, name=k) for k, v in val_dict.items()]
         data2 = type(data)(url=paths, storage_options=data.storage_options, metadata=data.metadata)
         if "concat_dim" in kw:
@@ -1351,7 +1364,8 @@ class XArrayPatternReader(XArrayDatasetReader):
             ccm = [ccm] if isinstance(ccm, str) else ccm
             for ind, cd in zip(indices, ccm):
                 ind.name = cd
-        return super()._read(data2, concat_dim=indices, combine="nested", **kw)
+        kw.setdefault("combine", "nested")
+        return super()._read(data2, concat_dim=indices, open_local=open_local, **kw)
 
 
 class RasterIOXarrayReader(FileReader):

--- a/intake/readers/readers.py
+++ b/intake/readers/readers.py
@@ -1293,7 +1293,7 @@ class XArrayDatasetReader(FileReader):
         if isinstance(data.url, (tuple, set, list)) and len(data.url) == 1:
             return open_dataset(data.url[0], **kw)
         elif (isinstance(data.url, (tuple, set, list)) and len(data.url) > 1) or (
-            isinstance(data.url, str) and "*" in data.url
+            isinstance(data.url, str) and "*" in data.url and not isinstance(data, datatypes.Zarr)
         ):
             ofs = [_.open() for _ in fsspec.open_files(data.url, **(data.storage_options or {}))]
             return open_mfdataset(ofs, **kw)

--- a/intake/utils.py
+++ b/intake/utils.py
@@ -324,3 +324,8 @@ def is_notebook() -> bool:
         return True
     except Exception:
         return False
+
+
+def is_fsspec_url(s: str) -> bool:
+    """Simple test to see if given string is likely an fsspec URL"""
+    return "://" in s or "::" in s

--- a/scripts/ci/environment-py310.yml
+++ b/scripts/ci/environment-py310.yml
@@ -43,3 +43,4 @@ dependencies:
   - pytest-postgresql
   - psycopg
   - siphon
+  - postgresql

--- a/scripts/ci/environment-py311.yml
+++ b/scripts/ci/environment-py311.yml
@@ -42,3 +42,4 @@ dependencies:
   - psycopg
   - python-duckdb
   - siphon
+  - postgresql

--- a/scripts/ci/environment-py312.yml
+++ b/scripts/ci/environment-py312.yml
@@ -42,3 +42,4 @@ dependencies:
   - psycopg
   - python-duckdb
   - siphon
+  - postgresql

--- a/scripts/ci/environment-py313.yml
+++ b/scripts/ci/environment-py313.yml
@@ -43,3 +43,4 @@ dependencies:
   - pytest-postgresql
   - psycopg
   - siphon
+  - postgresql

--- a/scripts/ci/environment-py39.yml
+++ b/scripts/ci/environment-py39.yml
@@ -41,3 +41,4 @@ dependencies:
   - pytest-postgresql
   - psycopg
   - siphon
+  - postgresql


### PR DESCRIPTION
Because xarray doesn't handle globs, and handles chained URLs poorly for some backends; but file-like objects are always good.