### PR TITLE
Fix handling of environment variables of type string

### DIFF
--- a/intake/config.py
+++ b/intake/config.py
@@ -35,6 +35,7 @@ defaults = {
     "extra_imports": [],
     "import_block_list": [],
     "reader_avoid": [],
+    "raise_on_error": False,
 }
 
 
@@ -157,8 +158,18 @@ class Config(dict):
                 k2 = k[7:].lower()
                 try:
                     val = ast.literal_eval(v)
-                except ValueError:
-                    pass
+                except (ValueError, SyntaxError) as e:
+                    if self["raise_on_error"]:
+                        logger.info(
+                            f"Environment variable '{v}' cannot be parsed by ast.literal_eval()"
+                        )
+                        raise e
+                    logger.warning(
+                        f"Failed to parse environment variable '{k}' (value: '{v}') using ast.literal_eval()."
+                        f"\nParsing as string."
+                        f"\nError was: '{type(e).__name__}: {e}'"
+                    )
+                    val = str(v)  # make sure it is a string
                 self[k2] = val
 
 

--- a/intake/config.py
+++ b/intake/config.py
@@ -48,6 +48,14 @@ class Config(dict):
     """Intake's dict-like config system
 
     Instance ``intake.conf`` is globally used throughout the package
+
+    Attributes:
+        environment_conf_parse : str
+                                 "ignore" (default), "warn" or raise an "error"
+                                 when parsing local environment variables as strings.
+        #TODO: Add other config values
+
+
     """
 
     def __init__(self, filename=None, **kwargs):

--- a/intake/config.py
+++ b/intake/config.py
@@ -13,6 +13,7 @@ import copy
 import logging
 import os
 import posixpath
+import warnings
 from os.path import expanduser
 
 import yaml
@@ -35,7 +36,7 @@ defaults = {
     "extra_imports": [],
     "import_block_list": [],
     "reader_avoid": [],
-    "raise_on_error": False,
+    "environment_conf_parse": "ignore",  # "error", "warn", "ignore"
 }
 
 
@@ -159,16 +160,17 @@ class Config(dict):
                 try:
                     val = ast.literal_eval(v)
                 except (ValueError, SyntaxError) as e:
-                    if self["raise_on_error"]:
+                    if self["environment_conf_parse"] == "error":
                         logger.info(
                             f"Environment variable '{v}' cannot be parsed by ast.literal_eval()"
                         )
                         raise e
-                    logger.warning(
-                        f"Failed to parse environment variable '{k}' (value: '{v}') using ast.literal_eval()."
-                        f"\nParsing as string."
-                        f"\nError was: '{type(e).__name__}: {e}'"
-                    )
+                    elif self["environment_conf_parse"] == "warn":
+                        warnings.warn(
+                            f"Failed to parse environment variable '{k}' (value: '{v}') using ast.literal_eval()."
+                            f"\nParsing as string."
+                            f"\nError was: '{type(e).__name__}: {e}'"
+                        )
                     val = str(v)  # make sure it is a string
                 self[k2] = val
 

--- a/intake/tests/test_config.py
+++ b/intake/tests/test_config.py
@@ -55,7 +55,7 @@ def test_load_env(conf):
     with temp_conf(conf) as fn:
         if conf["environment_conf_parse"] == "error":
             # When raise_on_error is True, ensure the exception is raised
-            with pytest.raises((ValueError, SyntaxError)):
+            with pytest.raises(ValueError, SyntaxError):
                 Config(fn)
         elif conf["environment_conf_parse"] == "warn":
             # When raise_on_error is False, ensure the variable is parsed as a string

--- a/intake/tests/test_config.py
+++ b/intake/tests/test_config.py
@@ -38,3 +38,20 @@ def test_pathdirs():
         "memory://path1",
         "memory://path2",
     ]
+
+
+@pytest.mark.parametrize("conf", [{"raise_on_error": True}, {"raise_on_error": False}])
+def test_load_env(conf):
+    # test the parsing of environment variables as strings
+    os.environ["INTAKE_CACHE"] = "./tmp"  # this causes a SyntaxError
+    os.environ["INTAKE_CACHE2"] = "tmp"  # this causes a ValueError
+    with temp_conf(conf) as fn:
+        if conf["raise_on_error"]:
+            # When raise_on_error is True, ensure the exception is raised
+            with pytest.raises((ValueError, SyntaxError)):
+                config = Config(fn)
+        else:
+            # When raise_on_error is False, ensure the variable is parsed as a string
+            config = Config(fn)
+            assert config["cache"] == "./tmp"
+            assert config["cache2"] == "tmp"


### PR DESCRIPTION
When local environment variables of the form `INTAKE_*="any-string"` are present on import, the load_env() function would return an `UnboundLocalError`.
This fixes that.

Fixes #855 

We could think about not warning the user about this behaviour. What do you think?
Best Johannes