### PR TITLE
New UP type: named options

### DIFF
--- a/intake/readers/tests/test_up.py
+++ b/intake/readers/tests/test_up.py
@@ -22,3 +22,16 @@ def test_basic():
         # supplied None as a value to int parameter
         pars = {"k": ["{p}", 1], "p": None}
         up.set_values({"p": p}, pars)
+
+
+def test_named_options():
+    from intake.readers import user_parameters as up
+
+    p = up.NamedOptionsUserParameter({"a": "athing", "b": "bthing"}, default="b")
+    pars = {"k": ["{p}", 1]}
+    out = up.set_values({"p": p}, pars)
+    assert out == {"k": ["bthing", 1]}
+
+    pars = {"k": ["{p}", 1], "p": "a"}
+    out = up.set_values({"p": p}, pars)
+    assert out == {"k": ["athing", 1]}

--- a/intake/readers/user_parameters.py
+++ b/intake/readers/user_parameters.py
@@ -108,8 +108,32 @@ class OptionsUserParameter(SimpleUserParameter):
         return self.coerce(value) in self.options
 
 
+class NamedOptionsUserParameter(SimpleUserParameter):
+    """One choice out of a given allow dictionary accessed by its keys
+
+    In this case, `dtype` is the types of the dictionary values, and
+    we have a separate "keytype" for the keys, str by default
+    """
+
+    def __init__(self, options, default, dtype=object, keytype=str, **kw):
+        super().__init__(default=options[default], dtype=dtype, **kw)
+        self.keytype = keytype
+        self.options = options
+
+    def coerce(self, value):
+        return self.options.get(value, None)
+
+    def _validate(self, value):
+        if not isinstance(value, self.keytype):
+            value = self.keytype(value)
+        return value in self.options.values()
+
+
 class MultiOptionUserParameter(OptionsUserParameter):
-    """Multiple choices out of a given allow list/tuple"""
+    """Multiple choices out of a given allow list/tuple
+
+    In this case, dtype is the type of each member of the list
+    """
 
     def __init__(self, options: list | tuple, dtype=object, **kw):
         super().__init__(options=options, dtype=dtype, **kw)


### PR DESCRIPTION
This is a useful multi-value UP type; but it does not solve the case of "I want the reader to choose between multiple possible data inputs", which probably requires changing the order in which arguments get processed.