### PR TITLE
Enable PDF and EPUB formats on readthedocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,7 @@
 version: 2
 
+formats: all
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Fixes #851 by enabling PDF and EPUB formats on RTD. Docs on this are also here:
https://docs.readthedocs.io/en/stable/guides/enable-offline-formats.html

They will appear on the RTD flyout in the bottom right hand corner.