### PR TITLE
Implement catalog mapper

### DIFF
--- a/intake/readers/datatypes.py
+++ b/intake/readers/datatypes.py
@@ -389,7 +389,7 @@ class OpenDAP(Service):
     structure = {"array"}
 
 
-class SQLQuery(Service):
+class SQLQuery(BaseData):
     """Query on a database-like service"""
 
     structure = {"sequence", "table"}

--- a/intake/readers/mixins.py
+++ b/intake/readers/mixins.py
@@ -29,7 +29,7 @@ class PipelineMixin(Completable):
         else:
             return out
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str):
         from intake.readers.convert import Pipeline
         from intake.readers.transform import GetItem
 
@@ -164,6 +164,9 @@ class Functioner(Completable):
             #  massive pipelines. E.g., dunders. For those, require `apply()`.
 
             outtype = self.reader.output_instance
+            if item.startswith("_"):
+                raise AttributeError(item)
+
             func = Method
             kw = {"method_name": item}
         else:

--- a/intake/readers/mixins.py
+++ b/intake/readers/mixins.py
@@ -101,6 +101,7 @@ class Functioner(Completable):
         from intake.readers.transform import GetItem
 
         # TODO: allow pattern match
+        breakpoint()
         if item in self.funcdict:
             func = self.funcdict[item]
             arg = ()
@@ -157,6 +158,12 @@ class Functioner(Completable):
 
         out = [(outtype, func) for outtype, func in self.funcdict.items() if func.__name__ == item]
         if not len(out):
+            # TODO: import class being acted on, to see if attribute requested
+            #  really is available. Perhaps tie to config option.
+            # TODO: exclude certain attributes that might be called during
+            #  a stack trace or other non-normal code, causing accidental
+            #  massive pipelines. E.g., dunders. For those, require `apply()`.
+
             outtype = self.reader.output_instance
             func = Method
             kw = {"method_name": item}

--- a/intake/readers/mixins.py
+++ b/intake/readers/mixins.py
@@ -101,7 +101,6 @@ class Functioner(Completable):
         from intake.readers.transform import GetItem
 
         # TODO: allow pattern match
-        breakpoint()
         if item in self.funcdict:
             func = self.funcdict[item]
             arg = ()

--- a/intake/readers/tests/cats/test_sql.py
+++ b/intake/readers/tests/cats/test_sql.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -8,6 +9,7 @@ pytest.importorskip("pytest_postgresql")
 pytest.importorskip("psycopg")
 
 
+@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="pytest_postgresql fails")
 @pytest.fixture  # uses pytest-postgresql
 def postgres_with_data(postgresql):
     """Check main postgresql fixture."""

--- a/intake/readers/tests/cats/test_sql.py
+++ b/intake/readers/tests/cats/test_sql.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pytest
 
@@ -9,7 +8,6 @@ pytest.importorskip("pytest_postgresql")
 pytest.importorskip("psycopg")
 
 
-@pytest.mark.skipif(sys.version_info[:2] == (3, 13), reason="pytest_postgresql fails")
 @pytest.fixture  # uses pytest-postgresql
 def postgres_with_data(postgresql):
     """Check main postgresql fixture."""

--- a/intake/readers/tests/test_workflows.py
+++ b/intake/readers/tests/test_workflows.py
@@ -45,6 +45,11 @@ def test_pipelines_in_catalogs(dataframe_file, df):
 def test_pipeline_steps(dataframe_file, df):
     data = intake.readers.datatypes.CSV(url=dataframe_file)
     reader = intake.readers.PandasCSV(data)
+    with pytest.raises(AttributeError):
+        # cannot auto on private methods; could still apply
+        out = reader._nonexistent()
+        breakpoint()
+
     reader2 = reader[["apple", "beet"]].set_index(keys="beet")
     stepper = reader2.read_stepwise()
     assert isinstance(stepper, convert.PipelineExecution)

--- a/intake/readers/transform.py
+++ b/intake/readers/transform.py
@@ -2,6 +2,7 @@
 """
 from __future__ import annotations
 
+import intake
 from intake.readers.convert import BaseConverter, SameType
 from intake.readers.utils import one_to_one
 
@@ -108,3 +109,41 @@ class GetItem(BaseConverter):
 
     def _read(self, item, data=None):
         return data[item]
+
+
+class CatalogMapper(BaseConverter):
+    instances = {"intake:Catalog": "intake:Catalog"}
+
+    def __init__(self, func, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.func = func
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(
+        self, in_cat: intake.Catalog, *args, transform=True, name_arg=None, read=False, **kwargs
+    ):
+        """
+        Parameters
+        ----------
+        transform: do we expect this to be a named transform that intake
+            already knows about?
+        name_arg: if give, pass the entry name to the action to be
+            performed using this ad the kwarg name
+        read: if True, execute the pipeline produced. This might be used
+            where the pipeline output is itself another reader.
+        """
+        out = intake.Catalog()
+        for name in in_cat.entries:
+            if name_arg:
+                kwargs[name_arg] = name
+            if transform:
+                pipe = in_cat[name].__getattr__(self.func)(*args, **kwargs)
+            else:
+                func = intake.import_name(self.func)
+                pipe = in_cat[name].apply(func, *args, **kwargs)
+            if read:
+                out[name] = pipe.read()
+            else:
+                out[name] = pipe
+        return out

--- a/scripts/ci/environment-py313.yml
+++ b/scripts/ci/environment-py313.yml
@@ -39,7 +39,7 @@ dependencies:
   - pre-commit
   - sqlalchemy
   - python-duckdb
-  - pytest-postgresql
+  - pytest-postgresql <7
   - psycopg
   - siphon
   - postgresql


### PR DESCRIPTION
Also adds "PandasToDuck" converter, and allows reading from Duck via arrow rather than pandas objects.

Fixes #854 

@dprovder, usage:
```
import intake
cat = intake.Catalog()
cat["pand"] = intake.readers.datatypes.Parquet("out.parquet").to_reader(outtype="pandas:DataFrame")
mapper = intake.readers.transform.CatalogMapper(func="PandasToDuck", transform=True)
cat2 = mapper.run(cat, conn="out.duckdb", name_arg="table", read=True)
```
Explanations:
- transform=True implies that the the readers in the catalog already know about a transform called PandasToDuck, which will be true for any pandas reader
- calling mapper.run works if you already have a Catalog. If instead you had a reader producing a catalog (from elsewhere), you would do `reader.CatalogMapper(...)
- for the meaning of name_arg and read, see the new docstring

Having executed the above, you will have a new catalog with the one entry for a table in duck with the same name as in the original catalog, in this case "pand".