### PR TITLE
Fix #887 getshell warnings

### DIFF
--- a/intake/catalog/tests/test_utils.py
+++ b/intake/catalog/tests/test_utils.py
@@ -4,6 +4,8 @@
 #
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -72,3 +74,14 @@ def test_coerce(value, dtype, expected):
     out = utils.coerce(dtype, value)
     assert out == expected
     assert type(out) == type(expected)
+
+
+def test_expand_defaults():
+    """
+    expand_defaults should not warn that getshell=False when it is True.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", category=UserWarning)
+        utils.expand_defaults(default="v2000-01-01", client=False, getenv=True, getshell=True)
+
+    assert True

--- a/intake/catalog/utils.py
+++ b/intake/catalog/utils.py
@@ -169,7 +169,7 @@ def expand_defaults(default, client=False, getenv=True, getshell=False):
             default = subprocess.check_output(cmd).rstrip().decode("utf8")
         except (subprocess.CalledProcessError, OSError):
             default = ""
-    else:
+    elif not getshell:
         warnings.warn("Shell command not executed due to getshell=False")
     r = re.match(r"client_shell\((.*)\)", default)
     if r and client and getshell:
@@ -178,7 +178,7 @@ def expand_defaults(default, client=False, getenv=True, getshell=False):
             default = subprocess.check_output(cmd).rstrip().decode("utf8")
         except (subprocess.CalledProcessError, OSError):
             default = ""
-    else:
+    elif not getshell:
         warnings.warn("Shell command not executed due to getshell=False")
     return default
 


### PR DESCRIPTION
Should fail - fix coming in a secondary commit.

This is a super minimal test failure & fix - the rest of the function is ~8 years old so I'd like to keep the behaviour as close to how it was as possible. 

Closes #887 